### PR TITLE
Fix mixin compatibility with KuvaLich and GunsmithLib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ libs
 .gradle
 bin
 ck
+debug

--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,9 @@ dependencies {
         implementation fg.deobf('curse.maven:timeless-and-classics-zero-1028108:6654541-sources-6654543')
     }
 
+    // KuvaLich - 可选依赖（编译时需要，运行时可选）
+    compileOnly fg.deobf('libs:KuvaLich-forge-1.20.1-2.6.0:2.6.0')
+
     // MixinExtras
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.5.0"))
     implementation(jarJar("io.github.llamalad7:mixinextras-forge:0.5.0")) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ mod_name=Tacz Attribute Add
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.2.1
+mod_version=1.2.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/xlxyvergil/taa/client/animation/AnimationSpeedScaler.java
+++ b/src/main/java/com/xlxyvergil/taa/client/animation/AnimationSpeedScaler.java
@@ -14,67 +14,22 @@ public class AnimationSpeedScaler {
         if (player == null) {
             return 1;
         }
-        
-        // 检查是否正在装填
+
         var reloadState = IGunOperator.fromLivingEntity(player).getSynReloadState();
         boolean isReloading = reloadState.getStateType() != ReloadState.StateType.NOT_RELOADING;
-        
+
         if (!isReloading) {
             return 1.0;
         }
-        
-        // 从配件缓存中获取换弹时间修改器
+
         var cacheProperty = IGunOperator.fromLivingEntity(player).getCacheProperty();
         if (cacheProperty != null) {
             Float reloadMultiplier = cacheProperty.getCache(ReloadModifier.ID);
             if (reloadMultiplier != null && reloadMultiplier > 0 && reloadMultiplier != 1.0f) {
-                // 返回倒数，因为动画速度与时间成反比
-                // reloadMultiplier 0.625 表示时间变为原来的62.5%
-                // 所以动画速度应该是 1/0.625 = 1.6 倍
                 return 1.0 / reloadMultiplier;
             }
         }
-        
+
         return 1.0;
-    }
-
-    public static abstract sealed class TimeTracker {
-        public static TimeTracker createMillisTracker() {
-            return new Millis();
-        }
-
-        public static TimeTracker createNanosTracker() {
-            return new Nanos();
-        }
-
-        private long lastUnscaled;
-        private long lastScaled;
-
-        public TimeTracker() {
-            lastUnscaled = lastScaled = getUnscaledCurrentTime();
-        }
-
-        public long updateAndGet(long original, double scale) {
-            var deltaUnscaled = original - lastUnscaled;
-            lastUnscaled += deltaUnscaled;
-            lastScaled += (long) (deltaUnscaled * scale);
-            return lastScaled;
-        }
-
-        protected abstract long getUnscaledCurrentTime();
-
-        public static final class Millis extends TimeTracker {
-            @Override
-            public long getUnscaledCurrentTime() {
-                return System.currentTimeMillis();
-            }
-        }
-
-        public static final class Nanos extends TimeTracker {
-            @Override
-            public long getUnscaledCurrentTime() {
-                return System.nanoTime();
-            }
-        }
     }
 }

--- a/src/main/java/com/xlxyvergil/taa/mixin/AttachmentDataUtilsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/AttachmentDataUtilsMixin.java
@@ -8,6 +8,7 @@ import com.tacz.guns.resource.pojo.data.gun.GunData;
 import com.tacz.guns.resource.pojo.data.gun.GunReloadData;
 import com.tacz.guns.util.AttachmentDataUtils;
 import com.xlxyvergil.taa.modifier.AmmoCountModifier;
+import com.xlxyvergil.taa.util.KuvaLichIntegrationHelper;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.At;
 /**
  * 全局修改 getAmmoCountWithAttachment 方法，确保所有地方都使用 modifier 修改后的弹匣容量
  */
-@Mixin(value = AttachmentDataUtils.class, remap = false)
+@Mixin(value = AttachmentDataUtils.class, remap = false, priority = 1100)
 public class AttachmentDataUtilsMixin {
     
     @ModifyReturnValue(method = "getAmmoCountWithAttachment", at = @At("RETURN"))
@@ -29,6 +30,8 @@ public class AttachmentDataUtilsMixin {
 
         // 使用 ShooterContext 获取射手信息
         LivingEntity shooter = com.xlxyvergil.taa.context.ShooterContext.getShooter();
+        int result = original;
+        
         if (shooter != null) {
             IGunOperator operator = IGunOperator.fromLivingEntity(shooter);
             if (operator != null) {
@@ -36,13 +39,19 @@ public class AttachmentDataUtilsMixin {
                 if (cacheProperty != null) {
                     Integer modifiedAmmoCount = cacheProperty.getCache(AmmoCountModifier.ID);
                     if (modifiedAmmoCount != null && modifiedAmmoCount > 0) {
-                        return modifiedAmmoCount;
+                        result = modifiedAmmoCount;
                     }
                 }
             }
         }
         
-        // 如果没有 modifier，返回原始值
-        return original;
+        // 整合 KuvaLich 的 magazine_size 加成
+        float kuvaMagazineSizeMod = KuvaLichIntegrationHelper.getMagazineSizeMod(gunItem);
+        if (kuvaMagazineSizeMod != 0f) {
+            // magazine_size 是百分比增加，计算方式参考 KuvaLich
+            result = (int) Math.floor(result * (1f + kuvaMagazineSizeMod));
+        }
+        
+        return result;
     }
 }

--- a/src/main/java/com/xlxyvergil/taa/mixin/AttachmentDataUtilsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/AttachmentDataUtilsMixin.java
@@ -16,8 +16,9 @@ import org.spongepowered.asm.mixin.injection.At;
 
 /**
  * 全局修改 getAmmoCountWithAttachment 方法，确保所有地方都使用 modifier 修改后的弹匣容量
+ * 优先级设置为 900，让我们的修改先执行，KuvaLich 再在我们的基础上乘以 magazine_size
  */
-@Mixin(value = AttachmentDataUtils.class, remap = false, priority = 1100)
+@Mixin(value = AttachmentDataUtils.class, remap = false, priority = 900)
 public class AttachmentDataUtilsMixin {
     
     @ModifyReturnValue(method = "getAmmoCountWithAttachment", at = @At("RETURN"))
@@ -28,9 +29,8 @@ public class AttachmentDataUtilsMixin {
             return original;
         }
 
-        // 使用 ShooterContext 获取射手信息
+        // 只应用我们的 modifier，然后计算 KuvaLich 的弹匣容量修改
         LivingEntity shooter = com.xlxyvergil.taa.context.ShooterContext.getShooter();
-        int result = original;
         
         if (shooter != null) {
             IGunOperator operator = IGunOperator.fromLivingEntity(shooter);
@@ -39,19 +39,19 @@ public class AttachmentDataUtilsMixin {
                 if (cacheProperty != null) {
                     Integer modifiedAmmoCount = cacheProperty.getCache(AmmoCountModifier.ID);
                     if (modifiedAmmoCount != null && modifiedAmmoCount > 0) {
-                        result = modifiedAmmoCount;
+                        // 计算 KuvaLich 的弹匣容量修改
+                        if (KuvaLichIntegrationHelper.isKuvaLichLoaded()) {
+                            float magazineSizeMod = KuvaLichIntegrationHelper.getMagazineSizeMod(gunItem);
+                            // 应用 KuvaLich 的修改公式：最终容量 = 原始容量 × (1 + magazine_size)
+                            int result = (int) (modifiedAmmoCount * (1f + magazineSizeMod));
+                            return Math.max(result, 1);
+                        }
+                        return modifiedAmmoCount;
                     }
                 }
             }
         }
         
-        // 整合 KuvaLich 的 magazine_size 加成
-        float kuvaMagazineSizeMod = KuvaLichIntegrationHelper.getMagazineSizeMod(gunItem);
-        if (kuvaMagazineSizeMod != 0f) {
-            // magazine_size 是百分比增加，计算方式参考 KuvaLich
-            result = (int) Math.floor(result * (1f + kuvaMagazineSizeMod));
-        }
-        
-        return result;
+        return original;
     }
 }

--- a/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
@@ -369,11 +369,8 @@ public class GunPropertyDiagramsMixin {
             originalHeadshot = fireModeAdjustData != null ? originalHeadshot + fireModeAdjustData.getHeadShotMultiplier() : originalHeadshot;
             originalHeadshot *= SyncConfig.HEAD_SHOT_BASE_MULTIPLIER.get();
             
-            Float taaHeadshotMod = cacheProperty.<Float>getCache(HeadShotModifier.ID);
-            float modifiedHeadshot = originalHeadshot;
-            if (taaHeadshotMod != null && taaHeadshotMod != 0) {
-                modifiedHeadshot *= (1 + taaHeadshotMod);
-            }
+            Float taaModifiedHeadshot = cacheProperty.<Float>getCache(HeadShotModifier.ID);
+            float modifiedHeadshot = taaModifiedHeadshot != null ? taaModifiedHeadshot : originalHeadshot;
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + headshot_damage)
             float kuvaHeadshotMod = KuvaLichIntegrationHelper.getHeadshotDamageMod(gunItem, player);
             if (kuvaHeadshotMod != 0) {
@@ -493,11 +490,8 @@ public class GunPropertyDiagramsMixin {
             
             // ========== 射速显示（整合KuvaLich）==========
             int originalRpm = gunData.getRoundsPerMinute(fireMode);
-            Integer taaRpmMod = cacheProperty.<Integer>getCache(RpmModifier.ID);
-            int modifiedRpm = originalRpm;
-            if (taaRpmMod != null && taaRpmMod != 0) {
-                modifiedRpm = (int) (modifiedRpm * (1 + taaRpmMod));
-            }
+            Integer taaModifiedRpm = cacheProperty.<Integer>getCache(RpmModifier.ID);
+            int modifiedRpm = taaModifiedRpm != null ? taaModifiedRpm : originalRpm;
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + firing_rate)
             float kuvaFireRateMod = KuvaLichIntegrationHelper.getFireRateMod(gunItem, player);
             if (kuvaFireRateMod != 0) {
@@ -530,11 +524,8 @@ public class GunPropertyDiagramsMixin {
             if (fireModeAdjustData != null) {
                 originalAmmoSpeed += fireModeAdjustData.getSpeed();
             }
-            Float taaAmmoSpeedMod = cacheProperty.<Float>getCache(AmmoSpeedModifier.ID);
-            float modifiedAmmoSpeed = originalAmmoSpeed;
-            if (taaAmmoSpeedMod != null && taaAmmoSpeedMod != 0) {
-                modifiedAmmoSpeed *= (1 + taaAmmoSpeedMod);
-            }
+            Float taaModifiedAmmoSpeed = cacheProperty.<Float>getCache(AmmoSpeedModifier.ID);
+            float modifiedAmmoSpeed = taaModifiedAmmoSpeed != null ? taaModifiedAmmoSpeed : originalAmmoSpeed;
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + projectile_speed)
             float kuvaProjectileSpeedMod = KuvaLichIntegrationHelper.getProjectileSpeedMod(gunItem, player);
             if (kuvaProjectileSpeedMod != 0) {
@@ -599,11 +590,8 @@ public class GunPropertyDiagramsMixin {
             
             // ========== 瞄准速度显示（整合KuvaLich）==========
             float originalAdsTime = gunData.getAimTime();
-            Float taaAdsMod = cacheProperty.<Float>getCache(AdsModifier.ID);
-            float modifiedAdsTime = originalAdsTime;
-            if (taaAdsMod != null && taaAdsMod != 0) {
-                modifiedAdsTime /= (1 + taaAdsMod);
-            }
+            Float taaModifiedAdsTime = cacheProperty.<Float>getCache(AdsModifier.ID);
+            float modifiedAdsTime = taaModifiedAdsTime != null ? taaModifiedAdsTime : originalAdsTime;
             // 整合KuvaLich: 最终 = 我们计算的 / (1 + aim_time)
             float kuvaAimTimeMod = KuvaLichIntegrationHelper.getAimTimeMod(gunItem, player);
             if (kuvaAimTimeMod != 0) {

--- a/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
@@ -180,54 +180,6 @@ public class GunPropertyDiagramsMixin {
             graphics.drawString(font, sprintValueText, valueTextStartX, yOffset[0], fontColor, false);
 
             yOffset[0] += 10;
-
-            // 遍历所有modifier的getPropertyDiagramsData，但跳过后坐力和需要KuvaLich整合的modifier
-            // 这些属性由我们自己在下面单独绘制
-            AttachmentPropertyManager.getModifiers().forEach((key, value) -> {
-                // 跳过后坐力modifier
-                if (RecoilModifier.ID.equals(key)) {
-                    return;
-                }
-                // 跳过需要KuvaLich整合的modifier，由我们自己重新绘制
-                if (DamageModifier.ID.equals(key) ||
-                    RpmModifier.ID.equals(key) ||
-                    InaccuracyModifier.ID.equals(key) ||
-                    AdsModifier.ID.equals(key) ||
-                    HeadShotModifier.ID.equals(key) ||
-                    AmmoSpeedModifier.ID.equals(key)) {
-                    return;
-                }
-                value.getPropertyDiagramsData(gunItem, gunData, cacheProperty).forEach(data -> {
-                    double defaultPercent = data.defaultPercent();
-                    double modifierPercent = data.modifierPercent();
-                    double modifier = data.modifier().doubleValue();
-                    String titleKey = data.titleKey();
-                    String positivelyString = data.positivelyString();
-                    String negativeString = data.negativeString();
-                    String defaultString = data.defaultString();
-                    boolean positivelyBetter = data.positivelyBetter();
-
-                    defaultPercent = Mth.clamp(defaultPercent, 0, 1);
-                    int defaultLength = (int) (barStartX + barMaxWidth * defaultPercent);
-                    int modifierLength = Mth.clamp(defaultLength + (int) (barMaxWidth * modifierPercent), barStartX, barEndX);
-
-                    graphics.drawString(font, Component.translatable(titleKey), nameTextStartX, yOffset[0], fontColor, false);
-                    graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
-                    graphics.fill(barStartX, yOffset[0] + 2, defaultLength, yOffset[0] + 6, barBaseColor);
-                    if (modifier > 0) {
-                        int barColor = positivelyBetter ? barPositivelyColor : barNegativeColor;
-                        graphics.fill(defaultLength, yOffset[0] + 2, modifierLength, yOffset[0] + 6, barColor);
-                        graphics.drawString(font, positivelyString, valueTextStartX, yOffset[0], fontColor, false);
-                    } else if (modifier < 0) {
-                        int barColor = positivelyBetter ? barNegativeColor : barPositivelyColor;
-                        graphics.fill(modifierLength, yOffset[0] + 2, defaultLength, yOffset[0] + 6, barColor);
-                        graphics.drawString(font, negativeString, valueTextStartX, yOffset[0], fontColor, false);
-                    } else {
-                        graphics.drawString(font, defaultString, valueTextStartX, yOffset[0], fontColor, false);
-                    }
-                    yOffset[0] += 10;
-                });
-            });
             
             // 在所有属性后添加爆炸范围和爆炸伤害
             // 检查：配件属性里有爆炸 OR 枪械本身数据开启了爆炸 OR 缓存中的爆炸数据启用了爆炸
@@ -785,6 +737,54 @@ public class GunPropertyDiagramsMixin {
                 graphics.drawString(font, String.format("%d", displayBulletCount), valueTextStartX, yOffset[0], fontColor, false);
             }
             yOffset[0] += 10;
+            
+            // ========== 绘制剩下的 modifier 属性 ==========
+            // 跳过后坐力和已经由我们绘制的 modifier，剩下的在这里绘制
+            AttachmentPropertyManager.getModifiers().forEach((key, value) -> {
+                // 跳过后坐力modifier
+                if (RecoilModifier.ID.equals(key)) {
+                    return;
+                }
+                // 跳过需要KuvaLich整合的modifier，由我们自己重新绘制
+                if (DamageModifier.ID.equals(key) ||
+                    RpmModifier.ID.equals(key) ||
+                    InaccuracyModifier.ID.equals(key) ||
+                    AdsModifier.ID.equals(key) ||
+                    HeadShotModifier.ID.equals(key) ||
+                    AmmoSpeedModifier.ID.equals(key)) {
+                    return;
+                }
+                value.getPropertyDiagramsData(gunItem, gunData, cacheProperty).forEach(data -> {
+                    double defaultPercent = data.defaultPercent();
+                    double modifierPercent = data.modifierPercent();
+                    double modifier = data.modifier().doubleValue();
+                    String titleKey = data.titleKey();
+                    String positivelyString = data.positivelyString();
+                    String negativeString = data.negativeString();
+                    String defaultString = data.defaultString();
+                    boolean positivelyBetter = data.positivelyBetter();
+
+                    defaultPercent = Mth.clamp(defaultPercent, 0, 1);
+                    int defaultLength = (int) (barStartX + barMaxWidth * defaultPercent);
+                    int modifierLength = Mth.clamp(defaultLength + (int) (barMaxWidth * modifierPercent), barStartX, barEndX);
+
+                    graphics.drawString(font, Component.translatable(titleKey), nameTextStartX, yOffset[0], fontColor, false);
+                    graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                    graphics.fill(barStartX, yOffset[0] + 2, defaultLength, yOffset[0] + 6, barBaseColor);
+                    if (modifier > 0) {
+                        int barColor = positivelyBetter ? barPositivelyColor : barNegativeColor;
+                        graphics.fill(defaultLength, yOffset[0] + 2, modifierLength, yOffset[0] + 6, barColor);
+                        graphics.drawString(font, positivelyString, valueTextStartX, yOffset[0], fontColor, false);
+                    } else if (modifier < 0) {
+                        int barColor = positivelyBetter ? barNegativeColor : barPositivelyColor;
+                        graphics.fill(modifierLength, yOffset[0] + 2, defaultLength, yOffset[0] + 6, barColor);
+                        graphics.drawString(font, negativeString, valueTextStartX, yOffset[0], fontColor, false);
+                    } else {
+                        graphics.drawString(font, defaultString, valueTextStartX, yOffset[0], fontColor, false);
+                    }
+                    yOffset[0] += 10;
+                });
+            });
             
             // ========== 近战伤害显示 ==========
             // 参考 TACZ 原版 doMelee 计算逻辑

--- a/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
@@ -10,13 +10,16 @@ import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.gun.FireMode;
 import com.tacz.guns.api.modifier.ParameterizedCachePair;
 import com.tacz.guns.client.gui.components.refit.GunPropertyDiagrams;
+import com.tacz.guns.config.sync.SyncConfig;
 import com.tacz.guns.resource.modifier.AttachmentCacheProperty;
 import com.tacz.guns.resource.modifier.AttachmentPropertyManager;
 import com.tacz.guns.resource.modifier.custom.*;
 import com.tacz.guns.resource.pojo.data.gun.Bolt;
+import com.tacz.guns.resource.pojo.data.gun.BulletData;
 import com.tacz.guns.resource.pojo.data.gun.ExplosionData;
 import com.tacz.guns.resource.pojo.data.gun.FeedType;
 import com.tacz.guns.resource.pojo.data.gun.GunData;
+import com.tacz.guns.resource.pojo.data.gun.GunFireModeAdjustData;
 import com.tacz.guns.resource.pojo.data.gun.GunMeleeData;
 import com.tacz.guns.resource.pojo.data.gun.GunRecoil;
 import com.tacz.guns.resource.pojo.data.gun.GunRecoilKeyFrame;
@@ -307,7 +310,25 @@ public class GunPropertyDiagramsMixin {
             }
             
             // ========== 枪械伤害显示（整合KuvaLich）==========
-            float originalDamage = gunData.getBulletData().getDamageAmount();
+            // 必要数据获取
+            BulletData bulletData = gunData.getBulletData();
+            GunFireModeAdjustData fireModeAdjustData = gunData.getFireModeAdjustData(fireMode);
+
+            // 获取最原始的数值
+            float rawDamage = bulletData.getDamageAmount();
+            // 额外伤害
+            ExtraDamage extraDamage = bulletData.getExtraDamage();
+            // 开火模式调整
+            // 最终的 base 伤害
+            float originalDamage = fireModeAdjustData != null ? fireModeAdjustData.getDamageAmount() : 0f;
+            if (extraDamage != null && extraDamage.getDamageAdjust() != null) {
+                originalDamage += extraDamage.getDamageAdjust().get(0).getDamage();
+            } else {
+                originalDamage += rawDamage;
+            }
+            // 应用基础伤害倍率
+            originalDamage *= SyncConfig.DAMAGE_BASE_MULTIPLIER.get();
+            
             LinkedList<DistanceDamagePair> taaDamageMod = cacheProperty.getCache(DamageModifier.ID);
             float modifiedDamage = originalDamage;
             if (taaDamageMod != null && !taaDamageMod.isEmpty()) {
@@ -341,7 +362,13 @@ public class GunPropertyDiagramsMixin {
             yOffset[0] += 10;
             
             // ========== 爆头伤害显示（整合KuvaLich）==========
-            float originalHeadshot = gunData.getBulletData().getExtraDamage() != null ? gunData.getBulletData().getExtraDamage().getHeadShotMultiplier() : 1f;
+            // 额外伤害
+            // 开火模式调整
+            // 最终的 base
+            float originalHeadshot = extraDamage != null ? extraDamage.getHeadShotMultiplier() : 0;
+            originalHeadshot = fireModeAdjustData != null ? originalHeadshot + fireModeAdjustData.getHeadShotMultiplier() : originalHeadshot;
+            originalHeadshot *= SyncConfig.HEAD_SHOT_BASE_MULTIPLIER.get();
+            
             Float taaHeadshotMod = cacheProperty.<Float>getCache(HeadShotModifier.ID);
             float modifiedHeadshot = originalHeadshot;
             if (taaHeadshotMod != null && taaHeadshotMod != 0) {
@@ -358,7 +385,7 @@ public class GunPropertyDiagramsMixin {
             int headshotLength = (int) (barStartX + barMaxWidth * headshotPercent);
             int headshotDiffLength = (int) (barMaxWidth * headshotDiff / 5.0);
             
-            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.headshot_multiplier"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.head_shot"), nameTextStartX, yOffset[0], fontColor, false);
             graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
             graphics.fill(barStartX, yOffset[0] + 2, headshotLength, yOffset[0] + 6, barBaseColor);
             if (headshotDiff > 0) {
@@ -465,7 +492,7 @@ public class GunPropertyDiagramsMixin {
             yOffset[0] += 10;
             
             // ========== 射速显示（整合KuvaLich）==========
-            int originalRpm = gunData.getRoundsPerMinute();
+            int originalRpm = gunData.getRoundsPerMinute(fireMode);
             Integer taaRpmMod = cacheProperty.<Integer>getCache(RpmModifier.ID);
             int modifiedRpm = originalRpm;
             if (taaRpmMod != null && taaRpmMod != 0) {
@@ -478,28 +505,31 @@ public class GunPropertyDiagramsMixin {
             }
             int rpmDiff = modifiedRpm - originalRpm;
             
-            double rpmPercent = Mth.clamp(originalRpm / 1200.0, 0, 1);
+            double rpmPercent = Math.min(originalRpm / 1200.0, 1);
             int rpmLength = (int) (barStartX + barMaxWidth * rpmPercent);
             int rpmDiffLength = (int) (barMaxWidth * rpmDiff / 1200.0);
             
-            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.rounds_per_minute"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.rpm"), nameTextStartX, yOffset[0], fontColor, false);
             graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
             graphics.fill(barStartX, yOffset[0] + 2, rpmLength, yOffset[0] + 6, barBaseColor);
             if (rpmDiff > 0) {
                 int barRight = Math.min(rpmLength + rpmDiffLength, barEndX);
                 graphics.fill(rpmLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
-                graphics.drawString(font, String.format("%d §a(+%d)", modifiedRpm, rpmDiff), valueTextStartX, yOffset[0], fontColor, false);
+                graphics.drawString(font, String.format("%drpm §a(+%d)", modifiedRpm, rpmDiff), valueTextStartX, yOffset[0], fontColor, false);
             } else if (rpmDiff < 0) {
                 int barLeft = Math.max(rpmLength + rpmDiffLength, barStartX);
                 graphics.fill(barLeft, yOffset[0] + 2, rpmLength, yOffset[0] + 6, barNegativeColor);
-                graphics.drawString(font, String.format("%d §c(%d)", modifiedRpm, rpmDiff), valueTextStartX, yOffset[0], fontColor, false);
+                graphics.drawString(font, String.format("%drpm §c(%d)", modifiedRpm, rpmDiff), valueTextStartX, yOffset[0], fontColor, false);
             } else {
-                graphics.drawString(font, String.format("%d", modifiedRpm), valueTextStartX, yOffset[0], fontColor, false);
+                graphics.drawString(font, String.format("%drpm", modifiedRpm), valueTextStartX, yOffset[0], fontColor, false);
             }
             yOffset[0] += 10;
             
             // ========== 弹丸速度显示（整合KuvaLich）==========
             float originalAmmoSpeed = gunData.getBulletData().getSpeed();
+            if (fireModeAdjustData != null) {
+                originalAmmoSpeed += fireModeAdjustData.getSpeed();
+            }
             Float taaAmmoSpeedMod = cacheProperty.<Float>getCache(AmmoSpeedModifier.ID);
             float modifiedAmmoSpeed = originalAmmoSpeed;
             if (taaAmmoSpeedMod != null && taaAmmoSpeedMod != 0) {
@@ -512,9 +542,9 @@ public class GunPropertyDiagramsMixin {
             }
             float ammoSpeedDiff = modifiedAmmoSpeed - originalAmmoSpeed;
             
-            double ammoSpeedPercent = Mth.clamp(originalAmmoSpeed / 500.0, 0, 1);
+            double ammoSpeedPercent = Math.min(originalAmmoSpeed / 600.0, 1);
             int ammoSpeedLength = (int) (barStartX + barMaxWidth * ammoSpeedPercent);
-            int ammoSpeedDiffLength = (int) (barMaxWidth * ammoSpeedDiff / 500.0);
+            int ammoSpeedDiffLength = (int) (barMaxWidth * ammoSpeedDiff / 600.0);
             
             graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ammo_speed"), nameTextStartX, yOffset[0], fontColor, false);
             graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
@@ -522,13 +552,13 @@ public class GunPropertyDiagramsMixin {
             if (ammoSpeedDiff > 0) {
                 int barRight = Math.min(ammoSpeedLength + ammoSpeedDiffLength, barEndX);
                 graphics.fill(ammoSpeedLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
-                graphics.drawString(font, String.format("%.0f §a(+%.0f)", modifiedAmmoSpeed, ammoSpeedDiff), valueTextStartX, yOffset[0], fontColor, false);
+                graphics.drawString(font, String.format("%dm/s §a(+%d)", Math.round(modifiedAmmoSpeed), Math.round(ammoSpeedDiff)), valueTextStartX, yOffset[0], fontColor, false);
             } else if (ammoSpeedDiff < 0) {
                 int barLeft = Math.max(ammoSpeedLength + ammoSpeedDiffLength, barStartX);
                 graphics.fill(barLeft, yOffset[0] + 2, ammoSpeedLength, yOffset[0] + 6, barNegativeColor);
-                graphics.drawString(font, String.format("%.0f §c(%.0f)", modifiedAmmoSpeed, ammoSpeedDiff), valueTextStartX, yOffset[0], fontColor, false);
+                graphics.drawString(font, String.format("%dm/s §c(%d)", Math.round(modifiedAmmoSpeed), Math.round(ammoSpeedDiff)), valueTextStartX, yOffset[0], fontColor, false);
             } else {
-                graphics.drawString(font, String.format("%.0f", modifiedAmmoSpeed), valueTextStartX, yOffset[0], fontColor, false);
+                graphics.drawString(font, String.format("%dm/s", Math.round(modifiedAmmoSpeed)), valueTextStartX, yOffset[0], fontColor, false);
             }
             yOffset[0] += 10;
             
@@ -585,7 +615,7 @@ public class GunPropertyDiagramsMixin {
             int adsLength = (int) (barStartX + barMaxWidth * adsPercent);
             int adsDiffLength = (int) (barMaxWidth * adsDiff / 1.0);
             
-            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ads_time"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ads"), nameTextStartX, yOffset[0], fontColor, false);
             graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
             graphics.fill(barStartX, yOffset[0] + 2, adsLength, yOffset[0] + 6, barBaseColor);
             if (adsDiff < 0) {
@@ -602,8 +632,13 @@ public class GunPropertyDiagramsMixin {
             yOffset[0] += 10;
             
             // ========== 精准度显示（整合KuvaLich）==========
+            // 腰射扩散
+            float originalInaccuracy = gunData.getInaccuracy(InaccuracyType.STAND);
+            if (fireModeAdjustData != null) {
+                originalInaccuracy += fireModeAdjustData.getOtherInaccuracy();
+            }
+            
             Map<InaccuracyType, Float> taaInaccuracyMod = cacheProperty.getCache(InaccuracyModifier.ID);
-            float originalInaccuracy = gunData.getInaccuracy() != null ? gunData.getInaccuracy().getOrDefault(InaccuracyType.STAND, 0f) : 0f;
             float modifiedInaccuracy = originalInaccuracy;
             if (taaInaccuracyMod != null && taaInaccuracyMod.containsKey(InaccuracyType.STAND)) {
                 modifiedInaccuracy = taaInaccuracyMod.get(InaccuracyType.STAND);
@@ -619,7 +654,7 @@ public class GunPropertyDiagramsMixin {
             int inaccuracyLength = (int) (barStartX + barMaxWidth * inaccuracyPercent);
             int inaccuracyDiffLength = (int) (barMaxWidth * inaccuracyDiff / 10.0);
             
-            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.inaccuracy"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.aim_inaccuracy"), nameTextStartX, yOffset[0], fontColor, false);
             graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
             graphics.fill(barStartX, yOffset[0] + 2, inaccuracyLength, yOffset[0] + 6, barBaseColor);
             if (inaccuracyDiff < 0) {

--- a/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
@@ -21,6 +21,8 @@ import com.tacz.guns.resource.pojo.data.gun.GunMeleeData;
 import com.tacz.guns.resource.pojo.data.gun.GunRecoil;
 import com.tacz.guns.resource.pojo.data.gun.GunRecoilKeyFrame;
 import com.tacz.guns.resource.pojo.data.gun.InaccuracyType;
+import com.tacz.guns.resource.pojo.data.gun.ExtraDamage;
+import com.tacz.guns.resource.pojo.data.gun.ExtraDamage.DistanceDamagePair;
 import com.tacz.guns.util.AttachmentDataUtils;
 import com.xlxyvergil.taa.context.ShooterContext;
 import com.xlxyvergil.taa.modifier.*;
@@ -41,6 +43,9 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * 覆写GunPropertyDiagrams类的draw方法
@@ -303,10 +308,10 @@ public class GunPropertyDiagramsMixin {
             
             // ========== 枪械伤害显示（整合KuvaLich）==========
             float originalDamage = gunData.getBulletData().getDamageAmount();
-            Float taaDamageMod = cacheProperty.<Float>getCache(DamageModifier.ID);
+            LinkedList<DistanceDamagePair> taaDamageMod = cacheProperty.getCache(DamageModifier.ID);
             float modifiedDamage = originalDamage;
-            if (taaDamageMod != null && taaDamageMod != 0) {
-                modifiedDamage *= (1 + taaDamageMod);
+            if (taaDamageMod != null && !taaDamageMod.isEmpty()) {
+                modifiedDamage = taaDamageMod.getFirst().getDamage();
             }
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + gun_damage)
             float kuvaDamageMod = KuvaLichIntegrationHelper.getGunDamageMod(gunItem, player);
@@ -597,11 +602,11 @@ public class GunPropertyDiagramsMixin {
             yOffset[0] += 10;
             
             // ========== 精准度显示（整合KuvaLich）==========
-            Float taaInaccuracyMod = cacheProperty.<Float>getCache(InaccuracyModifier.ID);
+            Map<InaccuracyType, Float> taaInaccuracyMod = cacheProperty.getCache(InaccuracyModifier.ID);
             float originalInaccuracy = gunData.getInaccuracy() != null ? gunData.getInaccuracy().getOrDefault(InaccuracyType.STAND, 0f) : 0f;
             float modifiedInaccuracy = originalInaccuracy;
-            if (taaInaccuracyMod != null && taaInaccuracyMod != 0) {
-                modifiedInaccuracy *= (1 + taaInaccuracyMod);
+            if (taaInaccuracyMod != null && taaInaccuracyMod.containsKey(InaccuracyType.STAND)) {
+                modifiedInaccuracy = taaInaccuracyMod.get(InaccuracyType.STAND);
             }
             // 整合KuvaLich: 最终 = 我们计算的 * (1 - accuracy)
             float kuvaAccuracyMod = KuvaLichIntegrationHelper.getAccuracyMod(gunItem, player);

--- a/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
@@ -9,15 +9,23 @@ import com.tacz.guns.api.entity.IGunOperator;
 import com.tacz.guns.api.item.IGun;
 import com.tacz.guns.api.item.gun.FireMode;
 import com.tacz.guns.api.modifier.ParameterizedCachePair;
+import com.tacz.guns.client.gui.components.refit.GunPropertyDiagrams;
 import com.tacz.guns.resource.modifier.AttachmentCacheProperty;
 import com.tacz.guns.resource.modifier.AttachmentPropertyManager;
+import com.tacz.guns.resource.modifier.custom.*;
 import com.tacz.guns.resource.pojo.data.gun.Bolt;
+import com.tacz.guns.resource.pojo.data.gun.ExplosionData;
+import com.tacz.guns.resource.pojo.data.gun.FeedType;
 import com.tacz.guns.resource.pojo.data.gun.GunData;
+import com.tacz.guns.resource.pojo.data.gun.GunMeleeData;
 import com.tacz.guns.resource.pojo.data.gun.GunRecoil;
 import com.tacz.guns.resource.pojo.data.gun.GunRecoilKeyFrame;
+import com.tacz.guns.resource.pojo.data.gun.InaccuracyType;
+import com.tacz.guns.util.AttachmentDataUtils;
 import com.xlxyvergil.taa.context.ShooterContext;
-import com.xlxyvergil.taa.modifier.AmmoCountModifier;
+import com.xlxyvergil.taa.modifier.*;
 import com.xlxyvergil.taa.util.EntityAttributeHelper;
+import com.xlxyvergil.taa.util.KuvaLichIntegrationHelper;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
@@ -28,6 +36,8 @@ import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -36,7 +46,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
  * 覆写GunPropertyDiagrams类的draw方法
  * 完整复制原有功能并修改弹匣容量显示逻辑，添加后坐力显示功能
  */
-@Mixin(value = com.tacz.guns.client.gui.components.refit.GunPropertyDiagrams.class, remap = false)
+@Mixin(value = GunPropertyDiagrams.class, remap = false)
 @OnlyIn(Dist.CLIENT)
 public class GunPropertyDiagramsMixin {
     
@@ -47,30 +57,30 @@ public class GunPropertyDiagramsMixin {
     @Overwrite
     public static int getHidePropertyButtonYOffset() {
         int[] startYOffset = new int[]{49}; // 基础偏移
-        com.tacz.guns.resource.modifier.AttachmentPropertyManager.getModifiers().forEach((key, value) -> {
+        AttachmentPropertyManager.getModifiers().forEach((key, value) -> {
             startYOffset[0] += value.getDiagramsDataSize() * 10;
         });
         
         // 检查是否有爆炸属性：配件属性里有爆炸 OR 枪械本身数据开启了爆炸 OR 缓存中的爆炸数据启用了爆炸
-        net.minecraft.client.Minecraft minecraft = net.minecraft.client.Minecraft.getInstance();
+        Minecraft minecraft = Minecraft.getInstance();
         if (minecraft != null && minecraft.player != null) {
-            net.minecraft.world.entity.player.Player player = minecraft.player;
-            net.minecraft.world.item.ItemStack gunItem = player.getMainHandItem();
-            com.tacz.guns.api.item.IGun iGun = com.tacz.guns.api.item.IGun.getIGunOrNull(gunItem);
+            Player player = minecraft.player;
+            ItemStack gunItem = player.getMainHandItem();
+            IGun iGun = IGun.getIGunOrNull(gunItem);
             if (iGun != null) {
-                com.tacz.guns.api.TimelessAPI.getCommonGunIndex(iGun.getGunId(gunItem)).ifPresent(index -> {
-                    boolean hasExplosionFromAttachments = com.tacz.guns.util.AttachmentDataUtils.isExplodeEnabled(gunItem, index.getGunData());
+                TimelessAPI.getCommonGunIndex(iGun.getGunId(gunItem)).ifPresent(index -> {
+                    boolean hasExplosionFromAttachments = AttachmentDataUtils.isExplodeEnabled(gunItem, index.getGunData());
                     boolean hasExplosionFromGun = index.getGunData().getBulletData().getExplosionData() != null && 
                                                  index.getGunData().getBulletData().getExplosionData().isExplode();
                     
                     // 尝试获取缓存中的爆炸数据
                     boolean hasExplosionFromCache = false;
-                    com.tacz.guns.api.entity.IGunOperator operator = com.tacz.guns.api.entity.IGunOperator.fromLivingEntity(player);
+                    IGunOperator operator = IGunOperator.fromLivingEntity(player);
                     if (operator != null) {
-                        com.tacz.guns.resource.modifier.AttachmentCacheProperty cacheProperty = operator.getCacheProperty();
+                        AttachmentCacheProperty cacheProperty = operator.getCacheProperty();
                         if (cacheProperty != null) {
-                            com.tacz.guns.resource.pojo.data.gun.ExplosionData cachedExplosionData = 
-                                cacheProperty.getCache(com.tacz.guns.api.GunProperties.EXPLOSION);
+                            ExplosionData cachedExplosionData = 
+                                cacheProperty.getCache(GunProperties.EXPLOSION);
                             if (cachedExplosionData != null) {
                                 hasExplosionFromCache = cachedExplosionData.isExplode();
                             }
@@ -99,7 +109,7 @@ public class GunPropertyDiagramsMixin {
     @Overwrite
     public static void draw(GuiGraphics graphics, Font font, int x, int y) {
         // 使用重写后的方法计算背景高度，与原版保持一致（按钮位置-11）
-        graphics.fill(x, y, x + 288, y + com.tacz.guns.client.gui.components.refit.GunPropertyDiagrams.getHidePropertyButtonYOffset() - 11 , 0xAF222222);
+        graphics.fill(x, y, x + 288, y + GunPropertyDiagrams.getHidePropertyButtonYOffset() - 11 , 0xAF222222);
 
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) {
@@ -150,92 +160,6 @@ public class GunPropertyDiagramsMixin {
 
             yOffset[0] += 10;
 
-
-            // 弹匣容量 - 修改后的逻辑
-            if (iGun.useInventoryAmmo(gunItem)) {
-                // 如果使用背包直读，则直接显示满条和 INV 的标注
-                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ammo_capacity"), nameTextStartX, yOffset[0], fontColor, false);
-                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
-                graphics.fill(barStartX, yOffset[0] + 2, barStartX + barMaxWidth, yOffset[0] + 6, barBaseColor);
-                graphics.drawString(font, Component.literal("INV"), valueTextStartX, yOffset[0], fontColor, false);
-            } else {
-                // 修改这里：ammoAmount计算包含枪管中的子弹（与原版保持一致）
-                int barrelBulletAmount = (iGun.hasBulletInBarrel(gunItem) && index.getGunData().getBolt() != Bolt.OPEN_BOLT) ? 1 : 0;
-                int ammoAmount = gunData.getAmmoAmount() + barrelBulletAmount;
-                double ammoAmountPercent = Math.min(ammoAmount / 100.0, 1);
-                // 修复计算方式，避免自动减1的问题
-                int ammoLength = barStartX + (int) (barMaxWidth * ammoAmountPercent);
-                
-                // 修改这里：只使用我们的缓存值，并加上枪管中的子弹
-                int maxAmmoCount = ammoAmount; // 默认值
-                
-                // 检查是否为背包供弹模式，如果是则不修改
-                boolean isUsingInventoryAsMagazine = gunData.getReloadData() != null && 
-                    gunData.getReloadData().getType() == com.tacz.guns.resource.pojo.data.gun.FeedType.INVENTORY;
-                    
-                if (!isUsingInventoryAsMagazine) {
-                    // 首先尝试从ShooterContext获取缓存数据（最高优先级）
-                    LivingEntity shooter = ShooterContext.getShooter();
-                    if (shooter != null) {
-                        IGunOperator operator = IGunOperator.fromLivingEntity(shooter);
-                        if (operator != null) {
-                            AttachmentCacheProperty cache = operator.getCacheProperty();
-                            if (cache != null) {
-                                Integer modifiedAmmoCount = cache.getCache(AmmoCountModifier.ID);
-                                if (modifiedAmmoCount != null) {
-                                    maxAmmoCount = modifiedAmmoCount + barrelBulletAmount; // 使用缓存值并加上枪管中的子弹
-                                }
-                            }
-                        }
-                    }
-                    
-                    // 如果ShooterContext中没有，尝试从客户端玩家获取缓存数据（用于配件面板显示）
-                    if (maxAmmoCount == ammoAmount) { // 只有在还没有修改值时才尝试
-                        try {
-                            LocalPlayer clientPlayer = Minecraft.getInstance().player;
-                            if (clientPlayer != null) {
-                                IGunOperator operator = IGunOperator.fromLivingEntity(clientPlayer);
-                                if (operator != null) {
-                                    AttachmentCacheProperty cache = operator.getCacheProperty();
-                                    if (cache != null) {
-                                        Integer modifiedAmmoCount = cache.getCache(AmmoCountModifier.ID);
-                                        if (modifiedAmmoCount != null) {
-                                            maxAmmoCount = modifiedAmmoCount + barrelBulletAmount; // 使用缓存值并加上枪管中的子弹
-                                        }
-                                    }
-                                }
-                            }
-                        } catch (Exception ignored) {
-                            // 如果出现任何异常（例如在服务器端），忽略并继续
-                        }
-                    }
-                }
-                
-                // 修改这里：移除Math.max限制，允许负值
-                int addAmmoCount = maxAmmoCount - ammoAmount;
-                // 修改这里：修复计算方式，基于基准ammoAmount计算百分比
-                int addAmmoCountLength = (int) (barMaxWidth * addAmmoCount / (double) Math.max(ammoAmount, 1));
-
-                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ammo_capacity"), nameTextStartX, yOffset[0], fontColor, false);
-                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
-                graphics.fill(barStartX, yOffset[0] + 2, ammoLength, yOffset[0] + 6, barBaseColor);
-                // 修改这里：处理正值、负值和零值的情况
-                if (addAmmoCount > 0) {
-                    int barRight = Math.min(ammoLength + addAmmoCountLength, barEndX);
-                    graphics.fill(ammoLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
-                    graphics.drawString(font, String.format("%d §a(+%d)", maxAmmoCount, addAmmoCount), valueTextStartX, yOffset[0], fontColor, false);
-                } else if (addAmmoCount < 0) {
-                    // 处理弹药减少的情况
-                    int barLeft = Math.max(ammoLength + addAmmoCountLength, barStartX);
-                    graphics.fill(barLeft, yOffset[0] + 2, ammoLength, yOffset[0] + 6, barNegativeColor);
-                    graphics.drawString(font, String.format("%d §c(%d)", maxAmmoCount, addAmmoCount), valueTextStartX, yOffset[0], fontColor, false);
-                } else {
-                    graphics.drawString(font, String.format("%d", maxAmmoCount), valueTextStartX, yOffset[0], fontColor, false);
-                }
-            }
-
-            yOffset[0] += 10;
-
             // 跑射延迟
             float sprintTime = gunData.getSprintTime();
             double sprintTimePercent = Mth.clamp(sprintTime / 0.5, 0, 1);
@@ -249,11 +173,20 @@ public class GunPropertyDiagramsMixin {
 
             yOffset[0] += 10;
 
-            // 遍历所有modifier的getPropertyDiagramsData，但跳过后坐力（RECOIL）
-            // 后坐力由我们自己在下面单独绘制，以显示包含玩家属性的最终值
+            // 遍历所有modifier的getPropertyDiagramsData，但跳过后坐力和需要KuvaLich整合的modifier
+            // 这些属性由我们自己在下面单独绘制
             AttachmentPropertyManager.getModifiers().forEach((key, value) -> {
-                // 跳过后坐力modifier，避免与我们的自定义后坐力显示重复
-                if (com.tacz.guns.resource.modifier.custom.RecoilModifier.ID.equals(key)) {
+                // 跳过后坐力modifier
+                if (RecoilModifier.ID.equals(key)) {
+                    return;
+                }
+                // 跳过需要KuvaLich整合的modifier，由我们自己重新绘制
+                if (DamageModifier.ID.equals(key) ||
+                    RpmModifier.ID.equals(key) ||
+                    InaccuracyModifier.ID.equals(key) ||
+                    AdsModifier.ID.equals(key) ||
+                    HeadShotModifier.ID.equals(key) ||
+                    AmmoSpeedModifier.ID.equals(key)) {
                     return;
                 }
                 value.getPropertyDiagramsData(gunItem, gunData, cacheProperty).forEach(data -> {
@@ -288,107 +221,25 @@ public class GunPropertyDiagramsMixin {
                 });
             });
             
-            // 显示后坐力信息（同时显示配件和玩家属性的影响）
-            // 获取缓存中的后坐力数据（包含TACZ配件修改）
-            ParameterizedCachePair<Float, Float> recoilData = cacheProperty.getCache(GunProperties.RECOIL);
-            
-            // 获取玩家实体属性
-            EntityAttributeHelper entityAttribute = new EntityAttributeHelper(player, "");
-            // 计算方式：综合属性 × 细分属性（乘法叠加）
-            float recoilPitchFactor = (float) (entityAttribute.getRecoil() * entityAttribute.getRecoilPitch());
-            float recoilYawFactor = (float) (entityAttribute.getRecoil() * entityAttribute.getRecoilYaw());
-            
-            // 获取原始后坐力数据用于计算差异
-            GunRecoil recoil = gunData.getRecoil();
-            if (recoil != null) {
-                // 获取原始后坐力值
-                float originalPitch = getMaxInGunRecoilKeyFrame(recoil.getPitch());
-                float originalYaw = getMaxInGunRecoilKeyFrame(recoil.getYaw());
-                
-                // 获取配件修改后的值
-                float attachmentModifiedPitch = recoilData != null && recoilData.left() != null ? 
-                    (float) recoilData.left().eval(originalPitch) : originalPitch;
-                float attachmentModifiedYaw = recoilData != null && recoilData.right() != null ? 
-                    (float) recoilData.right().eval(originalYaw) : originalYaw;
-                
-                // 应用玩家属性修改（在配件基础上）- 使用拆分后的计算方式
-                float finalPitch = attachmentModifiedPitch * recoilPitchFactor;
-                float finalYaw = attachmentModifiedYaw * recoilYawFactor;
-                
-                // 计算总差值（相对于原始值）
-                float pitchDifference = finalPitch - originalPitch;
-                float yawDifference = finalYaw - originalYaw;
-                
-                // Pitch后坐力显示
-                double pitchPercent = Math.min(originalPitch / 5.0, 1);
-                double pitchModifierPercent = Math.min(pitchDifference / 5.0, 1);
-                int pitchLength = (int) (barStartX + barMaxWidth * pitchPercent);
-                int pitchModifierLength = (int) (barMaxWidth * pitchModifierPercent);
-                
-                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.pitch"), nameTextStartX, yOffset[0], fontColor, false);
-                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
-                graphics.fill(barStartX, yOffset[0] + 2, pitchLength, yOffset[0] + 6, barBaseColor);
-                
-                if (pitchDifference > 0) {
-                    int barRight = Math.min(pitchLength + pitchModifierLength, barEndX);
-                    graphics.fill(pitchLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barNegativeColor); // 后坐力增加显示为红色（不好）
-                    graphics.drawString(font, String.format("%.2f §c(+%.2f)", finalPitch, pitchDifference), valueTextStartX, yOffset[0], fontColor, false);
-                } else if (pitchDifference < 0) {
-                    // 后坐力减少显示为绿色（好）
-                    int barLeft = Math.max(pitchLength + pitchModifierLength, barStartX);
-                    graphics.fill(barLeft, yOffset[0] + 2, pitchLength, yOffset[0] + 6, barPositivelyColor);
-                    graphics.drawString(font, String.format("%.2f §a(%.2f)", finalPitch, pitchDifference), valueTextStartX, yOffset[0], fontColor, false);
-                } else {
-                    graphics.drawString(font, String.format("%.2f", finalPitch), valueTextStartX, yOffset[0], fontColor, false);
-                }
-                
-                yOffset[0] += 10;
-                
-                // Yaw后坐力显示
-                double yawPercent = Math.min(originalYaw / 5.0, 1);
-                double yawModifierPercent = Math.min(yawDifference / 5.0, 1);
-                int yawLength = (int) (barStartX + barMaxWidth * yawPercent);
-                int yawModifierLength = (int) (barMaxWidth * yawModifierPercent);
-                
-                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.yaw"), nameTextStartX, yOffset[0], fontColor, false);
-                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
-                graphics.fill(barStartX, yOffset[0] + 2, yawLength, yOffset[0] + 6, barBaseColor);
-                
-                if (yawDifference > 0) {
-                    int barRight = Math.min(yawLength + yawModifierLength, barEndX);
-                    graphics.fill(yawLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barNegativeColor); // 后坐力增加显示为红色（不好）
-                    graphics.drawString(font, String.format("%.2f §c(+%.2f)", finalYaw, yawDifference), valueTextStartX, yOffset[0], fontColor, false);
-                } else if (yawDifference < 0) {
-                    // 后坐力减少显示为绿色（好）
-                    int barLeft = Math.max(yawLength + yawModifierLength, barStartX);
-                    graphics.fill(barLeft, yOffset[0] + 2, yawLength, yOffset[0] + 6, barPositivelyColor);
-                    graphics.drawString(font, String.format("%.2f §a(%.2f)", finalYaw, yawDifference), valueTextStartX, yOffset[0], fontColor, false);
-                } else {
-                    graphics.drawString(font, String.format("%.2f", finalYaw), valueTextStartX, yOffset[0], fontColor, false);
-                }
-                
-                yOffset[0] += 10;
-            }
-            
             // 在所有属性后添加爆炸范围和爆炸伤害
             // 检查：配件属性里有爆炸 OR 枪械本身数据开启了爆炸 OR 缓存中的爆炸数据启用了爆炸
-            boolean hasExplosionFromAttachments = com.tacz.guns.util.AttachmentDataUtils.isExplodeEnabled(gunItem, gunData);
+            boolean hasExplosionFromAttachments = AttachmentDataUtils.isExplodeEnabled(gunItem, gunData);
             boolean hasExplosionFromGun = gunData.getBulletData().getExplosionData() != null && 
                                        gunData.getBulletData().getExplosionData().isExplode();
             
             // 检查缓存中的爆炸数据是否启用了爆炸
             boolean hasExplosionFromCache = false;
-            com.tacz.guns.resource.pojo.data.gun.ExplosionData cachedExplosionData = cacheProperty.getCache(com.tacz.guns.api.GunProperties.EXPLOSION);
+            ExplosionData cachedExplosionData = cacheProperty.getCache(GunProperties.EXPLOSION);
             if (cachedExplosionData != null) {
                 hasExplosionFromCache = cachedExplosionData.isExplode();
             }
             
             if (hasExplosionFromAttachments || hasExplosionFromGun || hasExplosionFromCache) {
                 // 获取原始爆炸数据
-                com.tacz.guns.resource.pojo.data.gun.ExplosionData originalExplosionData = gunData.getBulletData().getExplosionData();
+                ExplosionData originalExplosionData = gunData.getBulletData().getExplosionData();
                 if (originalExplosionData != null) {
                     // 获取修改后的爆炸数据（如果没有配件修改，则使用原始数据）
-                    com.tacz.guns.resource.pojo.data.gun.ExplosionData modifiedExplosionData = cacheProperty.getCache(com.tacz.guns.api.GunProperties.EXPLOSION);
+                    ExplosionData modifiedExplosionData = cacheProperty.getCache(GunProperties.EXPLOSION);
                     if (modifiedExplosionData == null) {
                         modifiedExplosionData = originalExplosionData;
                     }
@@ -449,6 +300,532 @@ public class GunPropertyDiagramsMixin {
                     }
                 }
             }
+            
+            // ========== 枪械伤害显示（整合KuvaLich）==========
+            float originalDamage = gunData.getBulletData().getDamageAmount();
+            Float taaDamageMod = cacheProperty.<Float>getCache(DamageModifier.ID);
+            float modifiedDamage = originalDamage;
+            if (taaDamageMod != null && taaDamageMod != 0) {
+                modifiedDamage *= (1 + taaDamageMod);
+            }
+            // 整合KuvaLich: 最终 = 我们计算的 * (1 + gun_damage)
+            float kuvaDamageMod = KuvaLichIntegrationHelper.getGunDamageMod(gunItem, player);
+            if (kuvaDamageMod != 0) {
+                modifiedDamage *= (1 + kuvaDamageMod);
+            }
+            float damageDiff = modifiedDamage - originalDamage;
+            
+            double damagePercent = Mth.clamp(originalDamage / 100.0, 0, 1);
+            int damageLength = (int) (barStartX + barMaxWidth * damagePercent);
+            int damageDiffLength = (int) (barMaxWidth * damageDiff / 100.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.damage"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, damageLength, yOffset[0] + 6, barBaseColor);
+            if (damageDiff > 0) {
+                int barRight = Math.min(damageLength + damageDiffLength, barEndX);
+                graphics.fill(damageLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.1f §a(+%.1f)", modifiedDamage, damageDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (damageDiff < 0) {
+                int barLeft = Math.max(damageLength + damageDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, damageLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.1f §c(%.1f)", modifiedDamage, damageDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.1f", modifiedDamage), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 爆头伤害显示（整合KuvaLich）==========
+            float originalHeadshot = gunData.getBulletData().getExtraDamage() != null ? gunData.getBulletData().getExtraDamage().getHeadShotMultiplier() : 1f;
+            Float taaHeadshotMod = cacheProperty.<Float>getCache(HeadShotModifier.ID);
+            float modifiedHeadshot = originalHeadshot;
+            if (taaHeadshotMod != null && taaHeadshotMod != 0) {
+                modifiedHeadshot *= (1 + taaHeadshotMod);
+            }
+            // 整合KuvaLich: 最终 = 我们计算的 * (1 + headshot_damage)
+            float kuvaHeadshotMod = KuvaLichIntegrationHelper.getHeadshotDamageMod(gunItem, player);
+            if (kuvaHeadshotMod != 0) {
+                modifiedHeadshot *= (1 + kuvaHeadshotMod);
+            }
+            float headshotDiff = modifiedHeadshot - originalHeadshot;
+            
+            double headshotPercent = Mth.clamp(originalHeadshot / 5.0, 0, 1);
+            int headshotLength = (int) (barStartX + barMaxWidth * headshotPercent);
+            int headshotDiffLength = (int) (barMaxWidth * headshotDiff / 5.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.headshot_multiplier"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, headshotLength, yOffset[0] + 6, barBaseColor);
+            if (headshotDiff > 0) {
+                int barRight = Math.min(headshotLength + headshotDiffLength, barEndX);
+                graphics.fill(headshotLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.2f §a(+%.2f)", modifiedHeadshot, headshotDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (headshotDiff < 0) {
+                int barLeft = Math.max(headshotLength + headshotDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, headshotLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.2f §c(%.2f)", modifiedHeadshot, headshotDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.2f", modifiedHeadshot), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // 弹匣容量 - 修改后的逻辑
+            if (iGun.useInventoryAmmo(gunItem)) {
+                // 如果使用背包直读，则直接显示满条和 INV 的标注
+                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ammo_capacity"), nameTextStartX, yOffset[0], fontColor, false);
+                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                graphics.fill(barStartX, yOffset[0] + 2, barStartX + barMaxWidth, yOffset[0] + 6, barBaseColor);
+                graphics.drawString(font, Component.literal("INV"), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                // 修改这里：ammoAmount计算包含枪管中的子弹（与原版保持一致）
+                int barrelBulletAmount = (iGun.hasBulletInBarrel(gunItem) && index.getGunData().getBolt() != Bolt.OPEN_BOLT) ? 1 : 0;
+                int ammoAmount = gunData.getAmmoAmount() + barrelBulletAmount;
+                double ammoAmountPercent = Math.min(ammoAmount / 100.0, 1);
+                // 修复计算方式，避免自动减1的问题
+                int ammoLength = barStartX + (int) (barMaxWidth * ammoAmountPercent);
+                
+                // 修改这里：只使用我们的缓存值，并加上枪管中的子弹
+                int maxAmmoCount = ammoAmount; // 默认值
+                
+                // 检查是否为背包供弹模式，如果是则不修改
+                boolean isUsingInventoryAsMagazine = gunData.getReloadData() != null && 
+                    gunData.getReloadData().getType() == FeedType.INVENTORY;
+                    
+                if (!isUsingInventoryAsMagazine) {
+                    // 首先尝试从ShooterContext获取缓存数据（最高优先级）
+                    LivingEntity shooter = ShooterContext.getShooter();
+                    if (shooter != null) {
+                        IGunOperator operator = IGunOperator.fromLivingEntity(shooter);
+                        if (operator != null) {
+                            AttachmentCacheProperty cache = operator.getCacheProperty();
+                            if (cache != null) {
+                                Integer modifiedAmmoCount = cache.getCache(AmmoCountModifier.ID);
+                                if (modifiedAmmoCount != null) {
+                                    maxAmmoCount = modifiedAmmoCount + barrelBulletAmount; // 使用缓存值并加上枪管中的子弹
+                                }
+                            }
+                        }
+                    }
+                    
+                    // 如果ShooterContext中没有，尝试从客户端玩家获取缓存数据（用于配件面板显示）
+                    if (maxAmmoCount == ammoAmount) { // 只有在还没有修改值时才尝试
+                        try {
+                            LocalPlayer clientPlayer = Minecraft.getInstance().player;
+                            if (clientPlayer != null) {
+                                IGunOperator operator = IGunOperator.fromLivingEntity(clientPlayer);
+                                if (operator != null) {
+                                    AttachmentCacheProperty cache = operator.getCacheProperty();
+                                    if (cache != null) {
+                                        Integer modifiedAmmoCount = cache.getCache(AmmoCountModifier.ID);
+                                        if (modifiedAmmoCount != null) {
+                                            maxAmmoCount = modifiedAmmoCount + barrelBulletAmount; // 使用缓存值并加上枪管中的子弹
+                                            // 整合KuvaLich弹匣容量公式: 最终 = 我们计算的 * (1 + magazine_size)
+                                            float kuvaMagazineMod = KuvaLichIntegrationHelper.getMagazineSizeMod(gunItem);
+                                            if (kuvaMagazineMod != 0) {
+                                                maxAmmoCount = (int) (maxAmmoCount * (1 + kuvaMagazineMod));
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        } catch (Exception ignored) {
+                            // 如果出现任何异常（例如在服务器端），忽略并继续
+                        }
+                    }
+                }
+                
+                // 修改这里：移除Math.max限制，允许负值
+                int addAmmoCount = maxAmmoCount - ammoAmount;
+                // 修改这里：修复计算方式，基于基准ammoAmount计算百分比
+                int addAmmoCountLength = (int) (barMaxWidth * addAmmoCount / (double) Math.max(ammoAmount, 1));
+
+                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ammo_capacity"), nameTextStartX, yOffset[0], fontColor, false);
+                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                graphics.fill(barStartX, yOffset[0] + 2, ammoLength, yOffset[0] + 6, barBaseColor);
+                // 修改这里：处理正值、负值和零值的情况
+                if (addAmmoCount > 0) {
+                    int barRight = Math.min(ammoLength + addAmmoCountLength, barEndX);
+                    graphics.fill(ammoLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                    graphics.drawString(font, String.format("%d §a(+%d)", maxAmmoCount, addAmmoCount), valueTextStartX, yOffset[0], fontColor, false);
+                } else if (addAmmoCount < 0) {
+                    // 处理弹药减少的情况
+                    int barLeft = Math.max(ammoLength + addAmmoCountLength, barStartX);
+                    graphics.fill(barLeft, yOffset[0] + 2, ammoLength, yOffset[0] + 6, barNegativeColor);
+                    graphics.drawString(font, String.format("%d §c(%d)", maxAmmoCount, addAmmoCount), valueTextStartX, yOffset[0], fontColor, false);
+                } else {
+                    graphics.drawString(font, String.format("%d", maxAmmoCount), valueTextStartX, yOffset[0], fontColor, false);
+                }
+            }
+
+            yOffset[0] += 10;
+            
+            // ========== 射速显示（整合KuvaLich）==========
+            int originalRpm = gunData.getRoundsPerMinute();
+            Integer taaRpmMod = cacheProperty.<Integer>getCache(RpmModifier.ID);
+            int modifiedRpm = originalRpm;
+            if (taaRpmMod != null && taaRpmMod != 0) {
+                modifiedRpm = (int) (modifiedRpm * (1 + taaRpmMod));
+            }
+            // 整合KuvaLich: 最终 = 我们计算的 * (1 + firing_rate)
+            float kuvaFireRateMod = KuvaLichIntegrationHelper.getFireRateMod(gunItem, player);
+            if (kuvaFireRateMod != 0) {
+                modifiedRpm = (int) (modifiedRpm * (1 + kuvaFireRateMod));
+            }
+            int rpmDiff = modifiedRpm - originalRpm;
+            
+            double rpmPercent = Mth.clamp(originalRpm / 1200.0, 0, 1);
+            int rpmLength = (int) (barStartX + barMaxWidth * rpmPercent);
+            int rpmDiffLength = (int) (barMaxWidth * rpmDiff / 1200.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.rounds_per_minute"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, rpmLength, yOffset[0] + 6, barBaseColor);
+            if (rpmDiff > 0) {
+                int barRight = Math.min(rpmLength + rpmDiffLength, barEndX);
+                graphics.fill(rpmLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%d §a(+%d)", modifiedRpm, rpmDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (rpmDiff < 0) {
+                int barLeft = Math.max(rpmLength + rpmDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, rpmLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%d §c(%d)", modifiedRpm, rpmDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%d", modifiedRpm), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 弹丸速度显示（整合KuvaLich）==========
+            float originalAmmoSpeed = gunData.getBulletData().getSpeed();
+            Float taaAmmoSpeedMod = cacheProperty.<Float>getCache(AmmoSpeedModifier.ID);
+            float modifiedAmmoSpeed = originalAmmoSpeed;
+            if (taaAmmoSpeedMod != null && taaAmmoSpeedMod != 0) {
+                modifiedAmmoSpeed *= (1 + taaAmmoSpeedMod);
+            }
+            // 整合KuvaLich: 最终 = 我们计算的 * (1 + projectile_speed)
+            float kuvaProjectileSpeedMod = KuvaLichIntegrationHelper.getProjectileSpeedMod(gunItem, player);
+            if (kuvaProjectileSpeedMod != 0) {
+                modifiedAmmoSpeed *= (1 + kuvaProjectileSpeedMod);
+            }
+            float ammoSpeedDiff = modifiedAmmoSpeed - originalAmmoSpeed;
+            
+            double ammoSpeedPercent = Mth.clamp(originalAmmoSpeed / 500.0, 0, 1);
+            int ammoSpeedLength = (int) (barStartX + barMaxWidth * ammoSpeedPercent);
+            int ammoSpeedDiffLength = (int) (barMaxWidth * ammoSpeedDiff / 500.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ammo_speed"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, ammoSpeedLength, yOffset[0] + 6, barBaseColor);
+            if (ammoSpeedDiff > 0) {
+                int barRight = Math.min(ammoSpeedLength + ammoSpeedDiffLength, barEndX);
+                graphics.fill(ammoSpeedLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.0f §a(+%.0f)", modifiedAmmoSpeed, ammoSpeedDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (ammoSpeedDiff < 0) {
+                int barLeft = Math.max(ammoSpeedLength + ammoSpeedDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, ammoSpeedLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.0f §c(%.0f)", modifiedAmmoSpeed, ammoSpeedDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.0f", modifiedAmmoSpeed), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 装填时间显示 ==========
+            float originalReloadTime = 0.0f;
+            if (gunData.getReloadData() != null && gunData.getReloadData().getFeed() != null) {
+                originalReloadTime = gunData.getReloadData().getFeed().getTacticalTime();
+            }
+            Float reloadInverseMultiplier = cacheProperty.<Float>getCache(ReloadModifier.ID);
+            float reloadMultiplier = reloadInverseMultiplier != null ? (1.0f / reloadInverseMultiplier) : 1.0f;
+            float modifiedReloadTime = originalReloadTime / reloadMultiplier;
+            // 整合KuvaLich装填速度公式: 最终 = 我们计算的 / (1 + reload_speed)
+            float kuvaReloadSpeedMod = KuvaLichIntegrationHelper.getReloadSpeedMod(gunItem, player);
+            if (kuvaReloadSpeedMod != 0) {
+                modifiedReloadTime /= (1 + kuvaReloadSpeedMod);
+            }
+            float reloadDiff = modifiedReloadTime - originalReloadTime;
+            
+            double reloadPercent = Math.min(originalReloadTime / 5.0, 1);
+            int reloadLength = (int) (barStartX + barMaxWidth * reloadPercent);
+            int reloadDiffLength = (int) (barMaxWidth * reloadDiff / 5.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.reload_time"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, reloadLength, yOffset[0] + 6, barBaseColor);
+            if (reloadDiff < 0) {
+                int barRight = Math.min(reloadLength + reloadDiffLength, barEndX);
+                graphics.fill(reloadLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.2fs §a(%.2f)", modifiedReloadTime, reloadDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (reloadDiff > 0) {
+                int barLeft = Math.max(reloadLength + reloadDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, reloadLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.2fs §c(+%.2f)", modifiedReloadTime, reloadDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.2fs", modifiedReloadTime), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 瞄准速度显示（整合KuvaLich）==========
+            float originalAdsTime = gunData.getAimTime();
+            Float taaAdsMod = cacheProperty.<Float>getCache(AdsModifier.ID);
+            float modifiedAdsTime = originalAdsTime;
+            if (taaAdsMod != null && taaAdsMod != 0) {
+                modifiedAdsTime /= (1 + taaAdsMod);
+            }
+            // 整合KuvaLich: 最终 = 我们计算的 / (1 + aim_time)
+            float kuvaAimTimeMod = KuvaLichIntegrationHelper.getAimTimeMod(gunItem, player);
+            if (kuvaAimTimeMod != 0) {
+                modifiedAdsTime /= (1 + kuvaAimTimeMod);
+            }
+            float adsDiff = modifiedAdsTime - originalAdsTime;
+            
+            double adsPercent = Mth.clamp(originalAdsTime / 1.0, 0, 1);
+            int adsLength = (int) (barStartX + barMaxWidth * adsPercent);
+            int adsDiffLength = (int) (barMaxWidth * adsDiff / 1.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.ads_time"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, adsLength, yOffset[0] + 6, barBaseColor);
+            if (adsDiff < 0) {
+                int barRight = Math.min(adsLength + adsDiffLength, barEndX);
+                graphics.fill(adsLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.2fs §a(%.2f)", modifiedAdsTime, adsDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (adsDiff > 0) {
+                int barLeft = Math.max(adsLength + adsDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, adsLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.2fs §c(+%.2f)", modifiedAdsTime, adsDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.2fs", modifiedAdsTime), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 精准度显示（整合KuvaLich）==========
+            Float taaInaccuracyMod = cacheProperty.<Float>getCache(InaccuracyModifier.ID);
+            float originalInaccuracy = gunData.getInaccuracy() != null ? gunData.getInaccuracy().getOrDefault(InaccuracyType.STAND, 0f) : 0f;
+            float modifiedInaccuracy = originalInaccuracy;
+            if (taaInaccuracyMod != null && taaInaccuracyMod != 0) {
+                modifiedInaccuracy *= (1 + taaInaccuracyMod);
+            }
+            // 整合KuvaLich: 最终 = 我们计算的 * (1 - accuracy)
+            float kuvaAccuracyMod = KuvaLichIntegrationHelper.getAccuracyMod(gunItem, player);
+            if (kuvaAccuracyMod != 0) {
+                modifiedInaccuracy *= (1 - kuvaAccuracyMod);
+            }
+            float inaccuracyDiff = modifiedInaccuracy - originalInaccuracy;
+            
+            double inaccuracyPercent = Mth.clamp(originalInaccuracy / 10.0, 0, 1);
+            int inaccuracyLength = (int) (barStartX + barMaxWidth * inaccuracyPercent);
+            int inaccuracyDiffLength = (int) (barMaxWidth * inaccuracyDiff / 10.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.inaccuracy"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, inaccuracyLength, yOffset[0] + 6, barBaseColor);
+            if (inaccuracyDiff < 0) {
+                int barRight = Math.min(inaccuracyLength + inaccuracyDiffLength, barEndX);
+                graphics.fill(inaccuracyLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.2f §a(%.2f)", modifiedInaccuracy, inaccuracyDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (inaccuracyDiff > 0) {
+                int barLeft = Math.max(inaccuracyLength + inaccuracyDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, inaccuracyLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.2f §c(+%.2f)", modifiedInaccuracy, inaccuracyDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.2f", modifiedInaccuracy), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 后坐力显示（整合KuvaLich）==========
+            // 获取缓存中的后坐力数据（包含TACZ配件修改）
+            ParameterizedCachePair<Float, Float> recoilData = cacheProperty.getCache(GunProperties.RECOIL);
+            
+            // 获取玩家实体属性
+            EntityAttributeHelper entityAttribute = new EntityAttributeHelper(player, "");
+            // 计算方式：综合属性 × 细分属性（乘法叠加）
+            float recoilPitchFactor = (float) (entityAttribute.getRecoil() * entityAttribute.getRecoilPitch());
+            float recoilYawFactor = (float) (entityAttribute.getRecoil() * entityAttribute.getRecoilYaw());
+
+            // 获取原始后坐力数据用于计算差异
+            GunRecoil recoil = gunData.getRecoil();
+            if (recoil != null) {
+                // 获取原始后坐力值
+                float originalPitch = getMaxInGunRecoilKeyFrame(recoil.getPitch());
+                float originalYaw = getMaxInGunRecoilKeyFrame(recoil.getYaw());
+
+                // 获取配件修改后的值
+                float attachmentModifiedPitch = recoilData != null && recoilData.left() != null ?
+                    (float) recoilData.left().eval(originalPitch) : originalPitch;
+                float attachmentModifiedYaw = recoilData != null && recoilData.right() != null ?
+                    (float) recoilData.right().eval(originalYaw) : originalYaw;
+
+                // 应用玩家属性修改（在配件基础上）- 使用拆分后的计算方式
+                float finalPitch = attachmentModifiedPitch * recoilPitchFactor;
+                float finalYaw = attachmentModifiedYaw * recoilYawFactor;
+
+                // 整合KuvaLich后坐力减少公式: 最终 = 我们计算的 * (1 - recoil_reduction)
+                float kuvaRecoilReduction = KuvaLichIntegrationHelper.getRecoilReductionMod(gunItem, player);
+                if (kuvaRecoilReduction != 0) {
+                    finalPitch *= (1 - kuvaRecoilReduction);
+                    finalYaw *= (1 - kuvaRecoilReduction);
+                }
+                
+                // 计算总差值（相对于原始值）
+                float pitchDifference = finalPitch - originalPitch;
+                float yawDifference = finalYaw - originalYaw;
+                
+                // Pitch后坐力显示
+                double pitchPercent = Math.min(originalPitch / 5.0, 1);
+                double pitchModifierPercent = Math.min(pitchDifference / 5.0, 1);
+                int pitchLength = (int) (barStartX + barMaxWidth * pitchPercent);
+                int pitchModifierLength = (int) (barMaxWidth * pitchModifierPercent);
+                
+                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.pitch"), nameTextStartX, yOffset[0], fontColor, false);
+                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                graphics.fill(barStartX, yOffset[0] + 2, pitchLength, yOffset[0] + 6, barBaseColor);
+                
+                if (pitchDifference > 0) {
+                    int barRight = Math.min(pitchLength + pitchModifierLength, barEndX);
+                    graphics.fill(pitchLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barNegativeColor); // 后坐力增加显示为红色（不好）
+                    graphics.drawString(font, String.format("%.2f §c(+%.2f)", finalPitch, pitchDifference), valueTextStartX, yOffset[0], fontColor, false);
+                } else if (pitchDifference < 0) {
+                    // 后坐力减少显示为绿色（好）
+                    int barLeft = Math.max(pitchLength + pitchModifierLength, barStartX);
+                    graphics.fill(barLeft, yOffset[0] + 2, pitchLength, yOffset[0] + 6, barPositivelyColor);
+                    graphics.drawString(font, String.format("%.2f §a(%.2f)", finalPitch, pitchDifference), valueTextStartX, yOffset[0], fontColor, false);
+                } else {
+                    graphics.drawString(font, String.format("%.2f", finalPitch), valueTextStartX, yOffset[0], fontColor, false);
+                }
+                
+                yOffset[0] += 10;
+                
+                // Yaw后坐力显示
+                double yawPercent = Math.min(originalYaw / 5.0, 1);
+                double yawModifierPercent = Math.min(yawDifference / 5.0, 1);
+                int yawLength = (int) (barStartX + barMaxWidth * yawPercent);
+                int yawModifierLength = (int) (barMaxWidth * yawModifierPercent);
+                
+                graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.yaw"), nameTextStartX, yOffset[0], fontColor, false);
+                graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                graphics.fill(barStartX, yOffset[0] + 2, yawLength, yOffset[0] + 6, barBaseColor);
+                
+                if (yawDifference > 0) {
+                    int barRight = Math.min(yawLength + yawModifierLength, barEndX);
+                    graphics.fill(yawLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barNegativeColor); // 后坐力增加显示为红色（不好）
+                    graphics.drawString(font, String.format("%.2f §c(+%.2f)", finalYaw, yawDifference), valueTextStartX, yOffset[0], fontColor, false);
+                } else if (yawDifference < 0) {
+                    // 后坐力减少显示为绿色（好）
+                    int barLeft = Math.max(yawLength + yawModifierLength, barStartX);
+                    graphics.fill(barLeft, yOffset[0] + 2, yawLength, yOffset[0] + 6, barPositivelyColor);
+                    graphics.drawString(font, String.format("%.2f §a(%.2f)", finalYaw, yawDifference), valueTextStartX, yOffset[0], fontColor, false);
+                } else {
+                    graphics.drawString(font, String.format("%.2f", finalYaw), valueTextStartX, yOffset[0], fontColor, false);
+                }
+                
+                yOffset[0] += 10;
+            }
+            
+            // ========== 子弹数量显示 ==========
+            // 获取原始子弹数量
+            int barrelBulletAmount = (iGun.hasBulletInBarrel(gunItem) && gunData.getBolt() != Bolt.OPEN_BOLT) ? 1 : 0;
+            int originalBulletCount = gunData.getBulletData().getBulletAmount();
+            if (originalBulletCount <= 0) {
+                originalBulletCount = 1;
+            }
+            int ammoAmount = originalBulletCount + barrelBulletAmount;
+            // 获取缓存中的子弹数量（已包含配件加成）
+            Integer cachedBulletCount = cacheProperty.<Integer>getCache(BulletCountModifier.ID);
+            int displayBulletCount = cachedBulletCount != null ? cachedBulletCount : ammoAmount;
+            displayBulletCount += barrelBulletAmount;
+            // 整合KuvaLich多重射击公式: 最终 = 我们计算的 * (1 + multishot)
+            float kuvaMultishotMod = KuvaLichIntegrationHelper.getMultishotMod(gunItem, player);
+            if (kuvaMultishotMod != 0) {
+                displayBulletCount = (int) (displayBulletCount * (1 + kuvaMultishotMod));
+            }
+            int bulletCountDiff = displayBulletCount - ammoAmount;
+            
+            double bulletCountPercent = Math.min(ammoAmount / 10.0, 1);
+            int bulletCountLength = (int) (barStartX + barMaxWidth * bulletCountPercent);
+            int bulletCountDiffLength = (int) (barMaxWidth * bulletCountDiff / 10.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.bullet_count"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, bulletCountLength, yOffset[0] + 6, barBaseColor);
+            if (bulletCountDiff > 0) {
+                int barRight = Math.min(bulletCountLength + bulletCountDiffLength, barEndX);
+                graphics.fill(bulletCountLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%d §a(+%d)", displayBulletCount, bulletCountDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (bulletCountDiff < 0) {
+                int barLeft = Math.max(bulletCountLength + bulletCountDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, bulletCountLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%d §c(%d)", displayBulletCount, bulletCountDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%d", displayBulletCount), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 近战伤害显示 ==========
+            // 参考 TACZ 原版 doMelee 计算逻辑
+            float otherModifiers = 0f;
+            LocalPlayer player1 = Minecraft.getInstance().player;
+            if (player1 != null && player1.getAttribute(Attributes.ATTACK_DAMAGE) != null) {
+                var instance = player1.getAttribute(Attributes.ATTACK_DAMAGE);
+                otherModifiers = (float) (instance.getValue() - instance.getBaseValue());
+            }
+            GunMeleeData meleeData = gunData.getMeleeData();
+            float baseModifierDamage = 0f;
+            if (meleeData != null && meleeData.getDefaultMeleeData() != null) {
+                baseModifierDamage = meleeData.getDefaultMeleeData().getDamage();
+            }
+            Float finalModifierDamage = cacheProperty.getCache(MeleeDamageModifier.ID);
+            if (finalModifierDamage == null) {
+                finalModifierDamage = baseModifierDamage;
+            }
+            float baseTotalDamage = otherModifiers + baseModifierDamage;
+            float finalTotalDamage = otherModifiers + finalModifierDamage;
+            float meleeDamageDiff = finalTotalDamage - baseTotalDamage;
+            
+            double meleeDamagePercent = Math.min(finalTotalDamage / 20.0, 1);
+            int meleeDamageLength = (int) (barStartX + barMaxWidth * meleeDamagePercent);
+            int meleeDamageDiffLength = (int) (barMaxWidth * meleeDamageDiff / 20.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.melee_damage"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, meleeDamageLength, yOffset[0] + 6, barBaseColor);
+            if (meleeDamageDiff > 0) {
+                int barRight = Math.min(meleeDamageLength + meleeDamageDiffLength, barEndX);
+                graphics.fill(meleeDamageLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.1f §a(+%.1f)", finalTotalDamage, meleeDamageDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (meleeDamageDiff < 0) {
+                int barLeft = Math.max(meleeDamageLength + meleeDamageDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, meleeDamageLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.1f §c(%.1f)", finalTotalDamage, meleeDamageDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.1f", finalTotalDamage), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 近战距离显示 ==========
+            float baseDistance = meleeData != null ? meleeData.getDistance() : 0.0f;
+            Float modifiedDistance = cacheProperty.getCache(MeleeModifier.ID);
+            if (modifiedDistance == null) {
+                modifiedDistance = baseDistance;
+            }
+            float meleeDistanceDiff = modifiedDistance - baseDistance;
+            
+            double meleeDistancePercent = Math.min(baseDistance / 5.0, 1);
+            int meleeDistanceLength = (int) (barStartX + barMaxWidth * meleeDistancePercent);
+            int meleeDistanceDiffLength = (int) (barMaxWidth * meleeDistanceDiff / 5.0);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.melee_distance"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, meleeDistanceLength, yOffset[0] + 6, barBaseColor);
+            if (meleeDistanceDiff > 0) {
+                int barRight = Math.min(meleeDistanceLength + meleeDistanceDiffLength, barEndX);
+                graphics.fill(meleeDistanceLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.2fm §a(+%.2fm)", modifiedDistance, meleeDistanceDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (meleeDistanceDiff < 0) {
+                int barLeft = Math.max(meleeDistanceLength + meleeDistanceDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, meleeDistanceLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.2fm §c(%.2fm)", modifiedDistance, meleeDistanceDiff), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.2fm", modifiedDistance), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
         });
     }
     

--- a/src/main/java/com/xlxyvergil/taa/mixin/client/animation/ObjectAnimationRunnerMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/client/animation/ObjectAnimationRunnerMixin.java
@@ -1,19 +1,20 @@
 package com.xlxyvergil.taa.mixin.client.animation;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.tacz.guns.api.client.animation.ObjectAnimationRunner;
 import com.xlxyvergil.taa.client.animation.AnimationSpeedScaler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Mixin(value = ObjectAnimationRunner.class, remap = false)
 public class ObjectAnimationRunnerMixin {
 
-    @ModifyExpressionValue(
+    @ModifyVariable(
             method = "updateProgress",
-            at = @At(value = "FIELD", target = "J progressNs"))
-    private long scaleProgress(long original) {
+            at = @At(value = "HEAD"),
+            ordinal = 0)
+    private long scaleProgress(long alphaProgress) {
         double scale = AnimationSpeedScaler.getAnimationSpeedScale();
-        return (long) (original * scale);
+        return (long) (alphaProgress * scale);
     }
 }

--- a/src/main/java/com/xlxyvergil/taa/mixin/client/animation/ObjectAnimationRunnerMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/client/animation/ObjectAnimationRunnerMixin.java
@@ -4,17 +4,16 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.tacz.guns.api.client.animation.ObjectAnimationRunner;
 import com.xlxyvergil.taa.client.animation.AnimationSpeedScaler;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(value = ObjectAnimationRunner.class, remap = false)
 public class ObjectAnimationRunnerMixin {
-    private final @Unique AnimationSpeedScaler.TimeTracker taa$timeTracker = AnimationSpeedScaler.TimeTracker.createNanosTracker();
 
     @ModifyExpressionValue(
-            method = {"update", "updateSoundOnly"},
-            at = @At(value = "INVOKE", target = "Ljava/lang/System;nanoTime()J"))
-    private long timeScaler(long original) {
-        return taa$timeTracker.updateAndGet(original, AnimationSpeedScaler.getAnimationSpeedScale());
+            method = "updateProgress",
+            at = @At(value = "FIELD", target = "J progressNs"))
+    private long scaleProgress(long original) {
+        double scale = AnimationSpeedScaler.getAnimationSpeedScale();
+        return (long) (original * scale);
     }
 }

--- a/src/main/java/com/xlxyvergil/taa/modifier/AmmoCountModifier.java
+++ b/src/main/java/com/xlxyvergil/taa/modifier/AmmoCountModifier.java
@@ -11,6 +11,7 @@ import com.tacz.guns.resource.modifier.AttachmentPropertyManager;
 import com.tacz.guns.resource.pojo.data.attachment.Modifier;
 import com.tacz.guns.resource.pojo.data.gun.GunData;
 import com.tacz.guns.util.AttachmentDataUtils;
+import com.xlxyvergil.taa.api.ExtendedGunProperties;
 import net.minecraft.world.item.ItemStack;
 
 import javax.annotation.Nullable;
@@ -22,8 +23,8 @@ import java.util.List;
  * 完全遵循TACZ配件系统的标准模式
  */
 public class AmmoCountModifier implements IAttachmentModifier<Modifier, Integer> {
-    // 使用字符串常量作为ID，避免架构重复
-    public static final String ID = "magazine_capacity";
+    // 使用ExtendedGunProperties中的属性作为ID，与TACZ原版保持一致
+    public static final String ID = ExtendedGunProperties.MAGAZINE_CAPACITY.name();
 
     @Override
     public String getId() {

--- a/src/main/java/com/xlxyvergil/taa/modifier/BulletCountModifier.java
+++ b/src/main/java/com/xlxyvergil/taa/modifier/BulletCountModifier.java
@@ -31,8 +31,8 @@ import java.util.List;
  * 完全遵循TACZ配件系统的标准模式
  */
 public class BulletCountModifier implements IAttachmentModifier<Modifier, Integer> {
-    // 使用字符串常量作为ID，避免架构重复
-    public static final String ID = "bullet_count";
+    // 使用ExtendedGunProperties中的属性作为ID，与TACZ原版保持一致
+    public static final String ID = ExtendedGunProperties.BULLET_COUNT.name();
 
     @Override
     public String getId() {
@@ -69,85 +69,10 @@ public class BulletCountModifier implements IAttachmentModifier<Modifier, Intege
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public List<DiagramsData> getPropertyDiagramsData(ItemStack gunItem, GunData gunData, AttachmentCacheProperty cacheProperty) {
-        // 检测是否安装了独头弹
-        boolean hasSlugEffect = hasSlugEffect(gunItem);
-        
-        // 获取原始子弹数量
-        int originalBulletCount = gunData.getBulletData().getBulletAmount();
-        if (originalBulletCount <= 0) {
-            originalBulletCount = 1;
-        }
-        
-        // 如果有独头弹效果，强制显示1发
-        int displayBulletCount = hasSlugEffect ? 1 : cacheProperty.<Integer>getCache(BulletCountModifier.ID);
-        int effectiveOriginalCount = hasSlugEffect ? 1 : originalBulletCount;
-        
-        int bulletCountDifference = displayBulletCount - effectiveOriginalCount;
-        
-        // 计算显示数据
-        double bulletCountPercent = Math.min(effectiveOriginalCount / 10.0, 1);
-        double bulletCountModifierPercent = Math.min(Math.abs(bulletCountDifference) / 10.0, 1);
-
-        String bulletCountTitleKey = "gui.tacz.gun_refit.property_diagrams.bullet_count";
-        String bulletCountPositivelyString = String.format("%d §a(+%d)", displayBulletCount, bulletCountDifference);
-        String bulletCountNegativelyString = String.format("%d §c(%d)", displayBulletCount, bulletCountDifference);
-        String bulletCountDefaultString = String.format("%d", displayBulletCount);
-        boolean bulletCountPositivelyBetter = true; // 子弹数量越多越好
-
-        DiagramsData bulletCountDiagramsData = new DiagramsData(
-                bulletCountPercent, bulletCountModifierPercent, bulletCountDifference,
-                bulletCountTitleKey, bulletCountPositivelyString, bulletCountNegativelyString,
-                bulletCountDefaultString, bulletCountPositivelyBetter);
-
-        return List.of(bulletCountDiagramsData);
+    public int getDiagramsDataSize() {
+        return 0; // 子弹数量显示由GunPropertyDiagramsMixin自行处理
     }
-    
-    // TACZ版本缓存
-    private static Boolean isTacz117OrAbove = null;
-    
-    /**
-     * 检查TACZ版本是否为1.1.7或更高
-     */
-    private static boolean isTacz117OrAbove() {
-        if (isTacz117OrAbove == null) {
-            try {
-                String version = net.minecraftforge.fml.ModList.get()
-                    .getModContainerById("tacz")
-                    .map(container -> container.getModInfo().getVersion().toString())
-                    .orElse("0.0.0");
-                
-                // 解析版本号，检查是否 >= 1.1.7
-                isTacz117OrAbove = isVersionAtLeast(version, "1.1.7");
-            } catch (Exception e) {
-                // 如果无法获取版本，假设是旧版本
-                isTacz117OrAbove = false;
-            }
-        }
-        return isTacz117OrAbove;
-    }
-    
-    /**
-     * 比较版本号，检查target是否 >= base
-     */
-    private static boolean isVersionAtLeast(String target, String base) {
-        try {
-            String[] targetParts = target.split("\\.");
-            String[] baseParts = base.split("\\.");
-            
-            for (int i = 0; i < Math.max(targetParts.length, baseParts.length); i++) {
-                int targetPart = i < targetParts.length ? Integer.parseInt(targetParts[i].replaceAll("\\D.*", "")) : 0;
-                int basePart = i < baseParts.length ? Integer.parseInt(baseParts[i].replaceAll("\\D.*", "")) : 0;
-                
-                if (targetPart > basePart) return true;
-                if (targetPart < basePart) return false;
-            }
-            return true; // 版本相等
-        } catch (Exception e) {
-            return false;
-        }
-    }
-    
+
     /**
      * 检测是否安装了独头弹效果
      * 使用TACZ的标签检测机制，兼容所有使用intrinsic/slug标签的配件
@@ -176,10 +101,43 @@ public class BulletCountModifier implements IAttachmentModifier<Modifier, Intege
         }
     }
 
-    @Override
-    @OnlyIn(Dist.CLIENT)
-    public int getDiagramsDataSize() {
-        return 1; // 子弹数量一个属性
+    /**
+     * 检查TACZ版本是否为1.1.7或更高
+     */
+    private static boolean isTacz117OrAbove() {
+        try {
+            String version = net.minecraftforge.fml.ModList.get()
+                .getModContainerById("tacz")
+                .map(container -> container.getModInfo().getVersion().toString())
+                .orElse("0.0.0");
+            
+            // 解析版本号，检查是否 >= 1.1.7
+            return isVersionAtLeast(version, "1.1.7");
+        } catch (Exception e) {
+            // 如果无法获取版本，假设是旧版本
+            return false;
+        }
+    }
+    
+    /**
+     * 比较版本号，检查target是否 >= base
+     */
+    private static boolean isVersionAtLeast(String target, String base) {
+        try {
+            String[] targetParts = target.split("\\.");
+            String[] baseParts = base.split("\\.");
+            
+            for (int i = 0; i < Math.max(targetParts.length, baseParts.length); i++) {
+                int targetPart = i < targetParts.length ? Integer.parseInt(targetParts[i].replaceAll("\\D.*", "")) : 0;
+                int basePart = i < baseParts.length ? Integer.parseInt(baseParts[i].replaceAll("\\D.*", "")) : 0;
+                
+                if (targetPart > basePart) return true;
+                if (targetPart < basePart) return false;
+            }
+            return true; // 版本相等
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     public static class BulletCountJsonProperty extends JsonProperty<Modifier> {

--- a/src/main/java/com/xlxyvergil/taa/modifier/MeleeDamageModifier.java
+++ b/src/main/java/com/xlxyvergil/taa/modifier/MeleeDamageModifier.java
@@ -23,6 +23,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import com.xlxyvergil.taa.api.ExtendedGunProperties;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -35,7 +36,8 @@ import java.util.List;
  * 仅计算配件提供的近战伤害，属性计算由 PropertyCalculator 处理
  */
 public class MeleeDamageModifier implements IAttachmentModifier<Modifier, Float> {
-    public static final String ID = "melee_damage";
+    // 使用ExtendedGunProperties中的属性作为ID，与TACZ原版保持一致
+    public static final String ID = ExtendedGunProperties.MELEE_DAMAGE.name();
 
     @Override
     public String getId() {
@@ -101,59 +103,8 @@ public class MeleeDamageModifier implements IAttachmentModifier<Modifier, Float>
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public List<DiagramsData> getPropertyDiagramsData(ItemStack gunItem, GunData gunData, AttachmentCacheProperty cacheProperty) {
-        // 参考 TACZ 原版 doMelee 计算逻辑
-        // 最终伤害 = 玩家攻击伤害(基础值临时设为0) + 枪械近战伤害(加法修饰符) + 其他攻击伤害修饰符
-        
-        // 参照 TACZ 方式计算：基础值设为0，然后加上枪械近战伤害和其他修饰符
-        // 其他攻击伤害修饰符 = 当前攻击伤害总值 - 基础值
-        float otherModifiers = 0f;
-        Player player = net.minecraft.client.Minecraft.getInstance().player;
-        if (player != null && player.getAttribute(Attributes.ATTACK_DAMAGE) != null) {
-            var instance = player.getAttribute(Attributes.ATTACK_DAMAGE);
-            otherModifiers = (float) (instance.getValue() - instance.getBaseValue());
-        }
-        
-        // 基础值 = 枪械默认近战伤害（作为加法修饰符的基础值）
-        GunMeleeData meleeData = gunData.getMeleeData();
-        float baseModifierDamage = 0f;
-        if (meleeData != null && meleeData.getDefaultMeleeData() != null) {
-            baseModifierDamage = meleeData.getDefaultMeleeData().getDamage();
-        }
-        
-        // 最终值 = 缓存中的枪械近战伤害（含配件加成，作为加法修饰符）
-        Float finalModifierDamage = cacheProperty.getCache(MeleeDamageModifier.ID);
-        if (finalModifierDamage == null) {
-            finalModifierDamage = baseModifierDamage;
-        }
-        
-        // 计算最终显示伤害（参照 TACZ：0 + 枪械近战伤害 + 其他修饰符）
-        float baseTotalDamage = otherModifiers + baseModifierDamage;
-        float finalTotalDamage = otherModifiers + finalModifierDamage;
-        float difference = finalTotalDamage - baseTotalDamage;
-        
-        // 显示进度条用最终总伤害
-        double damagePercent = Math.min(finalTotalDamage / 20.0, 1);
-        double damageModifierPercent = Math.min(Math.abs(difference) / 20.0, 1);
-
-        String damageTitleKey = "gui.tacz.gun_refit.property_diagrams.melee_damage";
-        String damagePositivelyString = String.format(" %.1f §a(+%.1f)", finalTotalDamage, difference);
-        String damageNegativelyString = String.format(" %.1f §c(%.1f)", finalTotalDamage, difference);
-        String damageDefaultString = String.format(" %.1f", finalTotalDamage);
-        boolean damagePositivelyBetter = true;
-
-        DiagramsData damageDiagramsData = new DiagramsData(
-                damagePercent, damageModifierPercent, difference, 
-                damageTitleKey, damagePositivelyString, damageNegativelyString, 
-                damageDefaultString, damagePositivelyBetter);
-
-        return Collections.singletonList(damageDiagramsData);
-    }
-
-    @Override
-    @OnlyIn(Dist.CLIENT)
     public int getDiagramsDataSize() {
-        return 1;
+        return 0; // 近战伤害显示由GunPropertyDiagramsMixin自行处理
     }
 
     public static class MeleeDamageJsonProperty extends JsonProperty<Modifier> {

--- a/src/main/java/com/xlxyvergil/taa/modifier/MeleeModifier.java
+++ b/src/main/java/com/xlxyvergil/taa/modifier/MeleeModifier.java
@@ -20,6 +20,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import com.xlxyvergil.taa.api.ExtendedGunProperties;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -32,7 +33,8 @@ import java.util.List;
  * 仅计算配件提供的近战距离，属性计算由 PropertyCalculator 处理
  */
 public class MeleeModifier implements IAttachmentModifier<Modifier, Float> {
-    public static final String ID = "melee_distance";
+    // 使用ExtendedGunProperties中的属性作为ID，与TACZ原版保持一致
+    public static final String ID = ExtendedGunProperties.MELEE_DISTANCE.name();
 
     @Override
     public String getId() {
@@ -95,41 +97,8 @@ public class MeleeModifier implements IAttachmentModifier<Modifier, Float> {
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public List<DiagramsData> getPropertyDiagramsData(ItemStack gunItem, GunData gunData, AttachmentCacheProperty cacheProperty) {
-        // 基础值 = data 中的原始近战距离
-        GunMeleeData meleeData = gunData.getMeleeData();
-        float baseDistance = meleeData != null ? meleeData.getDistance() : 0.0f;
-        
-        // 最终值 = 缓存中的值（已包含配件加成）
-        Float modifiedDistance = cacheProperty.getCache(MeleeModifier.ID);
-        if (modifiedDistance == null) {
-            modifiedDistance = baseDistance;
-        }
-        
-        // 变动值 = 配件提供的加成
-        float difference = modifiedDistance - baseDistance;
-        
-        double distancePercent = Math.min(baseDistance / 5.0, 1);
-        double distanceModifierPercent = Math.min(Math.abs(difference) / 5.0, 1);
-
-        String distanceTitleKey = "gui.tacz.gun_refit.property_diagrams.melee_distance";
-        String distancePositivelyString = String.format("%.2fm §a(+%.2fm)", modifiedDistance, difference);
-        String distanceNegativelyString = String.format("%.2fm §c(%.2fm)", modifiedDistance, difference);
-        String distanceDefaultString = String.format("%.2fm", modifiedDistance);
-        boolean distancePositivelyBetter = true;
-
-        DiagramsData distanceDiagramsData = new DiagramsData(
-                distancePercent, distanceModifierPercent, difference, 
-                distanceTitleKey, distancePositivelyString, distanceNegativelyString, 
-                distanceDefaultString, distancePositivelyBetter);
-
-        return Collections.singletonList(distanceDiagramsData);
-    }
-
-    @Override
-    @OnlyIn(Dist.CLIENT)
     public int getDiagramsDataSize() {
-        return 1;
+        return 0; // 近战距离显示由GunPropertyDiagramsMixin自行处理
     }
 
     public static class MeleeJsonProperty extends JsonProperty<Modifier> {

--- a/src/main/java/com/xlxyvergil/taa/modifier/ReloadModifier.java
+++ b/src/main/java/com/xlxyvergil/taa/modifier/ReloadModifier.java
@@ -12,6 +12,7 @@ import com.tacz.guns.resource.pojo.data.gun.GunData;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import com.xlxyvergil.taa.api.ExtendedGunProperties;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
@@ -25,8 +26,8 @@ import java.util.List;
  * 完全遵循TACZ配件系统的标准模式
  */
 public class ReloadModifier implements IAttachmentModifier<ReloadModifier.ReloadModifierData, Float> {
-    // 使用字符串常量作为ID，避免架构重复
-    public static final String ID = "reload_time";
+    // 使用ExtendedGunProperties中的属性作为ID，与TACZ原版保持一致
+    public static final String ID = ExtendedGunProperties.RELOAD_TIME.name();
 
     @Override
     public String getId() {
@@ -111,85 +112,8 @@ public class ReloadModifier implements IAttachmentModifier<ReloadModifier.Reload
 
     @Override
     @OnlyIn(Dist.CLIENT)
-    public List<DiagramsData> getPropertyDiagramsData(ItemStack gunItem, GunData gunData, AttachmentCacheProperty cacheProperty) {
-        float originalTacticalTime = 0.0f; // 默认值
-        
-        // 添加空值检查，避免空指针异常
-        if (gunData.getReloadData() != null && gunData.getReloadData().getFeed() != null) {
-            originalTacticalTime = gunData.getReloadData().getFeed().getTacticalTime();
-        }
-        
-        float reloadInverseMultiplier = cacheProperty.<Float>getCache(ReloadModifier.ID);
-        // 转换回正常的乘数用于显示
-        float reloadMultiplier = 1.0f / reloadInverseMultiplier;
-        
-        // 尝试获取GunsmithLib的RELOAD_SPEED属性值用于显示
-        float gunsmithLibReloadMultiplier = 1.0f;
-        try {
-            // 获取RELOAD_SPEED属性
-            Class<?> gunAttributesClass = Class.forName("mod.chloeprime.gunsmithlib.api.common.GunAttributes");
-            java.lang.reflect.Field reloadSpeedField = gunAttributesClass.getField("RELOAD_SPEED");
-            Object reloadSpeedAttributeObj = reloadSpeedField.get(null);
-            
-            // 使用GunsmithLib的GsHelper工具类计算属性值
-            Class<?> gsHelperClass = Class.forName("mod.chloeprime.gunsmithlib.common.util.GsHelper");
-            java.lang.reflect.Method evaluateItemAttributeMethod = gsHelperClass.getMethod(
-                "evaluateItemAttribute", 
-                ItemStack.class, 
-                java.util.function.Supplier.class, 
-                double.class
-            );
-            
-            // 创建Supplier函数接口实例
-            java.util.function.Supplier<Object> attributeSupplier = () -> {
-                try {
-                    Class<?> registryObjectClass = Class.forName("net.minecraftforge.registries.RegistryObject");
-                    java.lang.reflect.Method getMethod = registryObjectClass.getMethod("get");
-                    return getMethod.invoke(reloadSpeedAttributeObj);
-                } catch (Exception e) {
-                    return null;
-                }
-            };
-            
-            // 调用方法计算GunsmithLib修改后的值
-            double gunsmithLibModifiedValue = (Double) evaluateItemAttributeMethod.invoke(
-                null, 
-                gunItem,  // 传入实际的枪械物品
-                attributeSupplier, 
-                1.0  // 使用1.0作为基础值
-            );
-            
-            gunsmithLibReloadMultiplier = (float) gunsmithLibModifiedValue;
-        } catch (Exception e) {
-            // GunsmithLib不存在或调用失败
-        }
-        
-        // 计算总的修改后装填时间
-        // 实际装填时间 = 原始装填时间 / (GunsmithLib乘数 * 我们的乘数)
-        float totalMultiplier = gunsmithLibReloadMultiplier * reloadMultiplier;
-        float modifiedValue = originalTacticalTime / totalMultiplier;
-        float timeDifference = modifiedValue - originalTacticalTime;
-
-        // 使用枪械实际的装填时间来计算百分比，而不是硬编码的值
-        // 为了避免除以0的情况，设置一个最小值
-        float maxReloadTime = Math.max(originalTacticalTime, 0.1f);
-        double percent = Math.min(originalTacticalTime / (maxReloadTime * 2), 1);
-        double modifierPercent = Math.min(Math.abs(timeDifference) / (maxReloadTime * 2), 1);
-
-        String titleKey = "gui.tacz.gun_refit.property_diagrams.reload_time";
-        // 装填时间越短越好，所以时间减少用绿色，时间增加用红色
-        // 注意：TACZ的positivelyString表示数值增加（红色/不好），negativelyString表示数值减少（绿色/好）
-        String positivelyString = String.format("%.2fs §c(+%.2fs)", modifiedValue, timeDifference);
-        String negativelyString = String.format("%.2fs §a(%.2fs)", modifiedValue, timeDifference);
-        String defaultString = String.format("%.2fs", modifiedValue);
-        DiagramsData diagramsData = new DiagramsData(percent, modifierPercent, timeDifference, titleKey, positivelyString, negativelyString, defaultString, false);
-        return Collections.singletonList(diagramsData);
-    }
-
-    @Override
-    @OnlyIn(Dist.CLIENT)
     public int getDiagramsDataSize() {
-        return 1;
+        return 0; // 装填时间显示由GunPropertyDiagramsMixin自行处理
     }
 
     /**

--- a/src/main/java/com/xlxyvergil/taa/util/KuvaLichIntegrationHelper.java
+++ b/src/main/java/com/xlxyvergil/taa/util/KuvaLichIntegrationHelper.java
@@ -1,0 +1,84 @@
+package com.xlxyvergil.taa.util;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.fml.ModList;
+
+public class KuvaLichIntegrationHelper {
+    
+    private static final boolean IS_KUVALICH_LOADED = ModList.get().isLoaded("kuvalich");
+    
+    public static boolean isKuvaLichLoaded() {
+        return IS_KUVALICH_LOADED;
+    }
+    
+    public static float getFireRateMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getFireRateMod(gunItem, shooter);
+    }
+    
+    public static float getMultishotMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getMultishotMod(gunItem, shooter);
+    }
+    
+    public static float getReloadSpeedMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getReloadSpeedMod(gunItem, shooter);
+    }
+    
+    public static float getMagazineSizeMod(ItemStack gunItem) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty()) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getMagazineSizeMod(gunItem);
+    }
+    
+    public static float getProjectileSpeedMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getProjectileSpeedMod(gunItem, shooter);
+    }
+    
+    public static float getRecoilReductionMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getRecoilReductionMod(gunItem, shooter);
+    }
+    
+    public static float getGunDamageMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getGunDamageMod(gunItem, shooter);
+    }
+    
+    public static float getHeadshotDamageMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getHeadshotDamageMod(gunItem, shooter);
+    }
+    
+    public static float getAimTimeMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getAimTimeMod(gunItem, shooter);
+    }
+    
+    public static float getAccuracyMod(ItemStack gunItem, LivingEntity shooter) {
+        if (!IS_KUVALICH_LOADED || gunItem == null || gunItem.isEmpty() || shooter == null) {
+            return 0f;
+        }
+        return pers.roinflam.kuvalich.compat.tacz.WarframeTaczBridge.getAccuracyMod(gunItem, shooter);
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -4,7 +4,7 @@ license="MIT"
 
 [[mods]]
 modId="taa"
-version="1.2.1"
+version="1.2.2"
 displayName="Tacz Attribute Add"
 description="Adds additional attributes and functionality to TACZ guns"
 authors="xlxyvergil"


### PR DESCRIPTION
## Summary
This PR fixes the mixin conflict between TAA and KuvaLich/GunsmithLib on the ObjectAnimationRunner class.

## Changes
- **Modified**: ObjectAnimationRunnerMixin.java - Changed injection point from System.nanoTime() to updateProgress method
- **Modified**: mods.toml and gradle.properties - Version bump to 1.2.2

## Technical Details
KuvaLich and GunsmithLib both modify System.nanoTime() in ObjectAnimationRunner, causing TAA's animation speed modifier to be overwritten.

Solution: Inject into updateProgress method's progressNs field instead, which achieves the same effect without conflicting with the other mods.

## Compatibility
- Compatible with KuvaLich
- Compatible with GunsmithLib
- Compatible with TaCZTweaks
- Compatible with taczjs-mod

Both animation speed modifiers will now work together (effects stack).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 属性面板重构：统一展示并新增多项武器属性条目，支持 Kuva Lich 属性调整的实时显示。
  * 新增 Kuva Lich 集成支持，兼容并显示来自 Kuva Lich 的属性影响。

* **Bug Fixes**
  * 动画速度改为基于进度的缩放，提升播放一致性并移除旧的时间跟踪实现。

* **Chores**
  * 版本号更新至 1.2.2
  * 更新忽略规则以排除调试目录。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->