### PR TITLE
feat: 添加暴击属性显示，支持增益减益条和多语言配置

### DIFF
--- a/src/main/java/com/xlxyvergil/taa/config/AttributeConfig.java
+++ b/src/main/java/com/xlxyvergil/taa/config/AttributeConfig.java
@@ -16,6 +16,21 @@ public class AttributeConfig {
     // 枪械伤害计算模式配置
     public static final ForgeConfigSpec.EnumValue<DamageCalculationMode> DAMAGE_CALCULATION_MODE;
     
+    // 暴击属性命名空间配置
+    public static final ForgeConfigSpec.ConfigValue<String> CRIT_CHANCE_ATTRIBUTE;
+    public static final ForgeConfigSpec.ConfigValue<String> CRIT_DAMAGE_ATTRIBUTE;
+    
+    // 语言配置
+    public static final ForgeConfigSpec.EnumValue<DisplayLanguage> DISPLAY_LANGUAGE;
+    
+    // 中文显示名称
+    public static final ForgeConfigSpec.ConfigValue<String> CRIT_CHANCE_NAME_ZH;
+    public static final ForgeConfigSpec.ConfigValue<String> CRIT_DAMAGE_NAME_ZH;
+    
+    // 英文显示名称
+    public static final ForgeConfigSpec.ConfigValue<String> CRIT_CHANCE_NAME_EN;
+    public static final ForgeConfigSpec.ConfigValue<String> CRIT_DAMAGE_NAME_EN;
+    
     static {
         BUILDER.push("枪械伤害计算设置");
         
@@ -25,6 +40,47 @@ public class AttributeConfig {
                         "ADDITIVE: 通用+特定-1",
                         "MULTIPLICATIVE: 通用*特定")
                 .defineEnum("damageCalculationMode", DamageCalculationMode.MAX);
+        
+        BUILDER.pop();
+        
+        BUILDER.push("暴击属性显示设置");
+        
+        CRIT_CHANCE_ATTRIBUTE = BUILDER
+                .comment("暴击率属性完整ID（格式：命名空间:属性名）",
+                        "默认: attributeslib:crit_chance",
+                        "示例: last_one:crit_chance")
+                .define("critChanceAttribute", "attributeslib:crit_chance");
+        
+        CRIT_DAMAGE_ATTRIBUTE = BUILDER
+                .comment("暴击伤害属性完整ID（格式：命名空间:属性名）",
+                        "默认: attributeslib:crit_damage",
+                        "示例: last_one:crit_damage")
+                .define("critDamageAttribute", "attributeslib:crit_damage");
+        
+        BUILDER.pop();
+        
+        BUILDER.push("多语言显示设置");
+        
+        DISPLAY_LANGUAGE = BUILDER
+                .comment("显示语言选择",
+                        "ZH: 中文", "EN: 英文")
+                .defineEnum("displayLanguage", DisplayLanguage.ZH);
+        
+        CRIT_CHANCE_NAME_ZH = BUILDER
+                .comment("暴击率显示名称（中文）")
+                .define("critChanceNameZh", "暴击率");
+        
+        CRIT_DAMAGE_NAME_ZH = BUILDER
+                .comment("暴击伤害显示名称（中文）")
+                .define("critDamageNameZh", "暴击伤害");
+        
+        CRIT_CHANCE_NAME_EN = BUILDER
+                .comment("暴击率显示名称（英文）")
+                .define("critChanceNameEn", "Critical Chance");
+        
+        CRIT_DAMAGE_NAME_EN = BUILDER
+                .comment("暴击伤害显示名称（英文）")
+                .define("critDamageNameEn", "Critical Damage");
                 
         BUILDER.pop();
         
@@ -51,6 +107,24 @@ public class AttributeConfig {
     }
     
     /**
+     * 显示语言枚举
+     */
+    public enum DisplayLanguage {
+        ZH("中文"),
+        EN("英文");
+        
+        private final String description;
+        
+        DisplayLanguage(String description) {
+            this.description = description;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+    }
+    
+    /**
      * 注册配置
      */
     public static void register() {
@@ -62,5 +136,42 @@ public class AttributeConfig {
      */
     public static DamageCalculationMode getDamageCalculationMode() {
         return DAMAGE_CALCULATION_MODE.get();
+    }
+    
+    /**
+     * 获取当前显示语言
+     */
+    public static DisplayLanguage getDisplayLanguage() {
+        return DISPLAY_LANGUAGE.get();
+    }
+    
+    /**
+     * 获取暴击率属性ID
+     */
+    public static String getCritChanceAttribute() {
+        return CRIT_CHANCE_ATTRIBUTE.get();
+    }
+    
+    /**
+     * 获取暴击伤害属性ID
+     */
+    public static String getCritDamageAttribute() {
+        return CRIT_DAMAGE_ATTRIBUTE.get();
+    }
+    
+    /**
+     * 获取暴击率显示名称（根据语言自动选择）
+     */
+    public static String getCritChanceName() {
+        return DISPLAY_LANGUAGE.get() == DisplayLanguage.ZH ? 
+            CRIT_CHANCE_NAME_ZH.get() : CRIT_CHANCE_NAME_EN.get();
+    }
+    
+    /**
+     * 获取暴击伤害显示名称（根据语言自动选择）
+     */
+    public static String getCritDamageName() {
+        return DISPLAY_LANGUAGE.get() == DisplayLanguage.ZH ? 
+            CRIT_DAMAGE_NAME_ZH.get() : CRIT_DAMAGE_NAME_EN.get();
     }
 }

--- a/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
+++ b/src/main/java/com/xlxyvergil/taa/mixin/GunPropertyDiagramsMixin.java
@@ -27,11 +27,13 @@ import com.tacz.guns.resource.pojo.data.gun.InaccuracyType;
 import com.tacz.guns.resource.pojo.data.gun.ExtraDamage;
 import com.tacz.guns.resource.pojo.data.gun.ExtraDamage.DistanceDamagePair;
 import com.tacz.guns.util.AttachmentDataUtils;
+import com.xlxyvergil.taa.config.AttributeConfig;
 import com.xlxyvergil.taa.context.ShooterContext;
 import com.xlxyvergil.taa.modifier.*;
+import com.xlxyvergil.taa.util.ApothicAttributesHelper;
 import com.xlxyvergil.taa.util.EntityAttributeHelper;
+import com.xlxyvergil.taa.util.GunsmithLibHelper;
 import com.xlxyvergil.taa.util.KuvaLichIntegrationHelper;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -106,6 +108,9 @@ public class GunPropertyDiagramsMixin {
         // 添加后坐力显示所需的空间（Pitch和Yaw各占10像素，共20像素）
         startYOffset[0] += 20;
         
+        // 添加暴击属性显示所需的空间（暴击率+暴击伤害=20像素）
+        startYOffset[0] += 20;
+        
         return startYOffset[0];
     }
     
@@ -116,8 +121,11 @@ public class GunPropertyDiagramsMixin {
      */
     @Overwrite
     public static void draw(GuiGraphics graphics, Font font, int x, int y) {
+        // 计算是否需要显示暴击属性
+        boolean showCritAttributes = true; // 始终尝试显示，由工具类处理null情况
         // 使用重写后的方法计算背景高度，与原版保持一致（按钮位置-11）
-        graphics.fill(x, y, x + 288, y + GunPropertyDiagrams.getHidePropertyButtonYOffset() - 11 , 0xAF222222);
+        // getHidePropertyButtonYOffset已经包含了暴击属性的额外高度
+        graphics.fill(x, y, x + 288, y + GunPropertyDiagrams.getHidePropertyButtonYOffset() - 11, 0xAF222222);
 
         LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) {
@@ -286,6 +294,13 @@ public class GunPropertyDiagramsMixin {
             if (taaDamageMod != null && !taaDamageMod.isEmpty()) {
                 modifiedDamage = taaDamageMod.getFirst().getDamage();
             }
+            
+            // 整合GunsmithLib
+            if (GunsmithLibHelper.isGunsmithLibLoaded()) {
+                int shrapnel = Math.max(bulletData.getBulletAmount(), 1);
+                modifiedDamage = (float) GunsmithLibHelper.getBulletDamage(gunItem, modifiedDamage, shrapnel);
+            }
+            
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + gun_damage)
             float kuvaDamageMod = KuvaLichIntegrationHelper.getGunDamageMod(gunItem, player);
             if (kuvaDamageMod != 0) {
@@ -323,6 +338,12 @@ public class GunPropertyDiagramsMixin {
             
             Float taaModifiedHeadshot = cacheProperty.<Float>getCache(HeadShotModifier.ID);
             float modifiedHeadshot = taaModifiedHeadshot != null ? taaModifiedHeadshot : originalHeadshot;
+            
+            // 整合GunsmithLib
+            if (GunsmithLibHelper.isGunsmithLibLoaded()) {
+                modifiedHeadshot = (float) GunsmithLibHelper.getHeadshotMultiplier(gunItem, modifiedHeadshot);
+            }
+            
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + headshot_damage)
             float kuvaHeadshotMod = KuvaLichIntegrationHelper.getHeadshotDamageMod(gunItem, player);
             if (kuvaHeadshotMod != 0) {
@@ -440,10 +461,16 @@ public class GunPropertyDiagramsMixin {
 
             yOffset[0] += 10;
             
-            // ========== 射速显示（整合KuvaLich）==========
+            // ========== 射速显示（整合KuvaLich + GunsmithLib）==========
             int originalRpm = gunData.getRoundsPerMinute(fireMode);
             Integer taaModifiedRpm = cacheProperty.<Integer>getCache(RpmModifier.ID);
             int modifiedRpm = taaModifiedRpm != null ? taaModifiedRpm : originalRpm;
+            
+            // 整合GunsmithLib
+            if (GunsmithLibHelper.isGunsmithLibLoaded()) {
+                modifiedRpm = (int) Math.round(GunsmithLibHelper.getRpm(gunItem, modifiedRpm));
+            }
+            
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + firing_rate)
             float kuvaFireRateMod = KuvaLichIntegrationHelper.getFireRateMod(gunItem, player);
             if (kuvaFireRateMod != 0) {
@@ -471,13 +498,19 @@ public class GunPropertyDiagramsMixin {
             }
             yOffset[0] += 10;
             
-            // ========== 弹丸速度显示（整合KuvaLich）==========
+            // ========== 弹丸速度显示（整合KuvaLich + GunsmithLib）==========
             float originalAmmoSpeed = gunData.getBulletData().getSpeed();
             if (fireModeAdjustData != null) {
                 originalAmmoSpeed += fireModeAdjustData.getSpeed();
             }
             Float taaModifiedAmmoSpeed = cacheProperty.<Float>getCache(AmmoSpeedModifier.ID);
             float modifiedAmmoSpeed = taaModifiedAmmoSpeed != null ? taaModifiedAmmoSpeed : originalAmmoSpeed;
+            
+            // 整合GunsmithLib
+            if (GunsmithLibHelper.isGunsmithLibLoaded()) {
+                modifiedAmmoSpeed = (float) GunsmithLibHelper.getBulletSpeed(gunItem, modifiedAmmoSpeed);
+            }
+            
             // 整合KuvaLich: 最终 = 我们计算的 * (1 + projectile_speed)
             float kuvaProjectileSpeedMod = KuvaLichIntegrationHelper.getProjectileSpeedMod(gunItem, player);
             if (kuvaProjectileSpeedMod != 0) {
@@ -637,6 +670,12 @@ public class GunPropertyDiagramsMixin {
                 float finalPitch = attachmentModifiedPitch * recoilPitchFactor;
                 float finalYaw = attachmentModifiedYaw * recoilYawFactor;
 
+                // 整合GunsmithLib后坐力属性
+                if (GunsmithLibHelper.isGunsmithLibLoaded()) {
+                    finalPitch = (float) GunsmithLibHelper.getVRecoil(gunItem, finalPitch);
+                    finalYaw = (float) GunsmithLibHelper.getHRecoil(gunItem, finalYaw);
+                }
+
                 // 整合KuvaLich后坐力减少公式: 最终 = 我们计算的 * (1 - recoil_reduction)
                 float kuvaRecoilReduction = KuvaLichIntegrationHelper.getRecoilReductionMod(gunItem, player);
                 if (kuvaRecoilReduction != 0) {
@@ -742,6 +781,105 @@ public class GunPropertyDiagramsMixin {
             }
             yOffset[0] += 10;
             
+            // ========== 穿甲倍率显示（整合GunsmithLib）==========
+            // 获取原始穿甲值
+            float originalArmorIgnore = gunData.getBulletData().getExtraDamage() != null ? 
+                gunData.getBulletData().getExtraDamage().getArmorIgnore() : 0f;
+            GunFireModeAdjustData fireModeAdjustDataForAp = gunData.getFireModeAdjustData(fireMode);
+            if (fireModeAdjustDataForAp != null) {
+                originalArmorIgnore += fireModeAdjustDataForAp.getArmorIgnore();
+            }
+            originalArmorIgnore *= SyncConfig.ARMOR_IGNORE_BASE_MULTIPLIER.get();
+            
+            // 获取缓存中的穿甲值（包含配件修改）
+            Float taaModifiedArmorIgnore = cacheProperty.<Float>getCache(ArmorIgnoreModifier.ID);
+            float modifiedArmorIgnore = taaModifiedArmorIgnore != null ? taaModifiedArmorIgnore : originalArmorIgnore;
+            
+            // 整合GunsmithLib
+            if (GunsmithLibHelper.isGunsmithLibLoaded()) {
+                modifiedArmorIgnore = (float) GunsmithLibHelper.getArmorPiercingRatio(gunItem, modifiedArmorIgnore);
+            }
+            
+            float armorIgnoreDiff = modifiedArmorIgnore - originalArmorIgnore;
+            
+            double armorIgnorePercent = Mth.clamp(originalArmorIgnore, 0, 1);
+            int armorIgnoreLength = (int) (barStartX + barMaxWidth * armorIgnorePercent);
+            int armorIgnoreDiffLength = (int) (barMaxWidth * armorIgnoreDiff);
+            
+            graphics.drawString(font, Component.translatable("gui.tacz.gun_refit.property_diagrams.armor_ignore"), nameTextStartX, yOffset[0], fontColor, false);
+            graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+            graphics.fill(barStartX, yOffset[0] + 2, armorIgnoreLength, yOffset[0] + 6, barBaseColor);
+            if (armorIgnoreDiff > 0) {
+                int barRight = Math.min(armorIgnoreLength + armorIgnoreDiffLength, barEndX);
+                graphics.fill(armorIgnoreLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                graphics.drawString(font, String.format("%.1f%% §a(+%.1f%%)", modifiedArmorIgnore * 100, armorIgnoreDiff * 100), valueTextStartX, yOffset[0], fontColor, false);
+            } else if (armorIgnoreDiff < 0) {
+                int barLeft = Math.max(armorIgnoreLength + armorIgnoreDiffLength, barStartX);
+                graphics.fill(barLeft, yOffset[0] + 2, armorIgnoreLength, yOffset[0] + 6, barNegativeColor);
+                graphics.drawString(font, String.format("%.1f%% §c(%.1f%%)", modifiedArmorIgnore * 100, armorIgnoreDiff * 100), valueTextStartX, yOffset[0], fontColor, false);
+            } else {
+                graphics.drawString(font, String.format("%.1f%%", modifiedArmorIgnore * 100), valueTextStartX, yOffset[0], fontColor, false);
+            }
+            yOffset[0] += 10;
+            
+            // ========== 暴击属性显示 ==========
+            if (showCritAttributes) {
+                ApothicAttributesHelper.CritAttributeData critChanceData = ApothicAttributesHelper.getCritChanceData(player);
+                ApothicAttributesHelper.CritAttributeData critDamageData = ApothicAttributesHelper.getCritDamageData(player);
+                
+                if (critChanceData != null) {
+                    String critChanceName = AttributeConfig.getCritChanceName();
+                    
+                    // 暴击率条：使用最终值计算进度条长度
+                    double critChancePercent = Mth.clamp(critChanceData.modifiedValue / (critChanceData.isDecimalFormat ? 1.0 : 1000.0), 0, 1);
+                    int critChanceLength = (int) (barStartX + barMaxWidth * critChancePercent);
+                    int critChanceBaseLength = (int) (barStartX + barMaxWidth * Mth.clamp(critChanceData.baseValue / (critChanceData.isDecimalFormat ? 1.0 : 1000.0), 0, 1));
+                    
+                    graphics.drawString(font, Component.literal(critChanceName), nameTextStartX, yOffset[0], fontColor, false);
+                    graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                    graphics.fill(barStartX, yOffset[0] + 2, critChanceBaseLength, yOffset[0] + 6, barBaseColor);
+                    
+                    if (critChanceData.difference > 0) {
+                        int barRight = Math.min(critChanceLength, barEndX);
+                        graphics.fill(critChanceBaseLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                        graphics.drawString(font, critChanceData.formatValue(critChanceData.modifiedValue) + " §a(+" + critChanceData.formatValue(critChanceData.difference) + ")", valueTextStartX, yOffset[0], fontColor, false);
+                    } else if (critChanceData.difference < 0) {
+                        int barLeft = Math.max(critChanceLength, barStartX);
+                        graphics.fill(barLeft, yOffset[0] + 2, critChanceBaseLength, yOffset[0] + 6, barNegativeColor);
+                        graphics.drawString(font, critChanceData.formatValue(critChanceData.modifiedValue) + " §c(" + critChanceData.formatValue(critChanceData.difference) + ")", valueTextStartX, yOffset[0], fontColor, false);
+                    } else {
+                        graphics.drawString(font, critChanceData.formatValue(critChanceData.modifiedValue), valueTextStartX, yOffset[0], fontColor, false);
+                    }
+                    yOffset[0] += 10;
+                }
+                
+                if (critDamageData != null) {
+                    String critDamageName = AttributeConfig.getCritDamageName();
+                    
+                    // 暴击伤害条：使用最终值计算进度条长度
+                    double critDamagePercent = Mth.clamp(critDamageData.modifiedValue / (critDamageData.isDecimalFormat ? 100.0 : 1000.0), 0, 1);
+                    int critDamageLength = (int) (barStartX + barMaxWidth * critDamagePercent);
+                    int critDamageBaseLength = (int) (barStartX + barMaxWidth * Mth.clamp(critDamageData.baseValue / (critDamageData.isDecimalFormat ? 100.0 : 1000.0), 0, 1));
+                    
+                    graphics.drawString(font, Component.literal(critDamageName), nameTextStartX, yOffset[0], fontColor, false);
+                    graphics.fill(barStartX, yOffset[0] + 2, barEndX, yOffset[0] + 6, barBackgroundColor);
+                    graphics.fill(barStartX, yOffset[0] + 2, critDamageBaseLength, yOffset[0] + 6, barBaseColor);
+                    
+                    if (critDamageData.difference > 0) {
+                        int barRight = Math.min(critDamageLength, barEndX);
+                        graphics.fill(critDamageBaseLength, yOffset[0] + 2, barRight, yOffset[0] + 6, barPositivelyColor);
+                        graphics.drawString(font, critDamageData.formatValue(critDamageData.modifiedValue) + " §a(+" + critDamageData.formatValue(critDamageData.difference) + ")", valueTextStartX, yOffset[0], fontColor, false);
+                    } else if (critDamageData.difference < 0) {
+                        int barLeft = Math.max(critDamageLength, barStartX);
+                        graphics.fill(barLeft, yOffset[0] + 2, critDamageBaseLength, yOffset[0] + 6, barNegativeColor);
+                        graphics.drawString(font, critDamageData.formatValue(critDamageData.modifiedValue) + " §c(" + critDamageData.formatValue(critDamageData.difference) + ")", valueTextStartX, yOffset[0], fontColor, false);
+                    } else {
+                        graphics.drawString(font, critDamageData.formatValue(critDamageData.modifiedValue), valueTextStartX, yOffset[0], fontColor, false);
+                    }
+                    yOffset[0] += 10;
+                }
+            }
+            
             // ========== 绘制剩下的 modifier 属性 ==========
             // 跳过后坐力和已经由我们绘制的 modifier，剩下的在这里绘制
             AttachmentPropertyManager.getModifiers().forEach((key, value) -> {
@@ -749,13 +887,14 @@ public class GunPropertyDiagramsMixin {
                 if (RecoilModifier.ID.equals(key)) {
                     return;
                 }
-                // 跳过需要KuvaLich整合的modifier，由我们自己重新绘制
+                // 跳过需要KuvaLich/GunsmithLib整合的modifier，由我们自己重新绘制
                 if (DamageModifier.ID.equals(key) ||
                     RpmModifier.ID.equals(key) ||
                     InaccuracyModifier.ID.equals(key) ||
                     AdsModifier.ID.equals(key) ||
                     HeadShotModifier.ID.equals(key) ||
-                    AmmoSpeedModifier.ID.equals(key)) {
+                    AmmoSpeedModifier.ID.equals(key) ||
+                    ArmorIgnoreModifier.ID.equals(key)) {
                     return;
                 }
                 value.getPropertyDiagramsData(gunItem, gunData, cacheProperty).forEach(data -> {

--- a/src/main/java/com/xlxyvergil/taa/util/ApothicAttributesHelper.java
+++ b/src/main/java/com/xlxyvergil/taa/util/ApothicAttributesHelper.java
@@ -1,0 +1,110 @@
+package com.xlxyvergil.taa.util;
+
+import com.xlxyvergil.taa.config.AttributeConfig;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/**
+ * 暴击属性获取工具类
+ * 支持从配置文件读取属性命名空间，默认使用 attributeslib
+ */
+public class ApothicAttributesHelper {
+    
+    /**
+     * 暴击属性数据类
+     */
+    public static class CritAttributeData {
+        public final double baseValue;
+        public final double modifiedValue;
+        public final double difference;
+        public final boolean isDecimalFormat;
+        
+        public CritAttributeData(double baseValue, double modifiedValue, double difference, boolean isDecimalFormat) {
+            this.baseValue = baseValue;
+            this.modifiedValue = modifiedValue;
+            this.difference = difference;
+            this.isDecimalFormat = isDecimalFormat;
+        }
+        
+        /**
+         * 格式化显示值
+         */
+        public String formatValue(double value) {
+            if (isDecimalFormat) {
+                return String.format("%.2f%%", value * 100);
+            } else {
+                return String.format("%.2f%%", value);
+            }
+        }
+    }
+    
+    /**
+     * 获取玩家的暴击率属性数据
+     * @param player 玩家对象
+     * @return 暴击率属性数据（包含基础值、最终值、差异）
+     */
+    public static CritAttributeData getCritChanceData(Player player) {
+        if (player == null) {
+            return null;
+        }
+        
+        String attributeId = AttributeConfig.getCritChanceAttribute();
+        return getAttributeData(player, attributeId);
+    }
+    
+    /**
+     * 获取玩家的暴击伤害属性数据
+     * @param player 玩家对象
+     * @return 暴击伤害属性数据（包含基础值、最终值、差异）
+     */
+    public static CritAttributeData getCritDamageData(Player player) {
+        if (player == null) {
+            return null;
+        }
+        
+        String attributeId = AttributeConfig.getCritDamageAttribute();
+        return getAttributeData(player, attributeId);
+    }
+    
+    /**
+     * 通用方法：根据属性ID获取属性数据
+     * @param player 玩家对象
+     * @param attributeId 属性完整ID（格式：命名空间:属性名）
+     * @return 属性数据（包含基础值、最终值、差异）
+     */
+    private static CritAttributeData getAttributeData(Player player, String attributeId) {
+        try {
+            ResourceLocation location = new ResourceLocation(attributeId);
+            Attribute attribute = ForgeRegistries.ATTRIBUTES.getValue(location);
+            
+            if (attribute == null) {
+                return null;
+            }
+            
+            AttributeInstance instance = player.getAttribute(attribute);
+            if (instance == null) {
+                return null;
+            }
+            
+            double baseValue = attribute.getDefaultValue();
+            double modifiedValue = instance.getValue();
+            double difference = modifiedValue - baseValue;
+            
+            // 通过 crit_damage 基础值判断格式化方式
+            String damageAttributeId = AttributeConfig.getCritDamageAttribute();
+            ResourceLocation damageLocation = new ResourceLocation(damageAttributeId);
+            Attribute damageAttribute = ForgeRegistries.ATTRIBUTES.getValue(damageLocation);
+            
+            boolean isDecimalFormat = damageAttribute != null && damageAttribute.getDefaultValue() < 10.0;
+            
+            return new CritAttributeData(baseValue, modifiedValue, difference, isDecimalFormat);
+            
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

为枪械属性图表 UI 新增可配置的爆击属性显示功能，包括本地化支持以及与外部属性和枪械库的集成。

New Features:
- 使用玩家属性数据，在枪械属性图表中显示暴击几率和暴击伤害条。
- 允许通过配置文件设置暴击属性 ID 和显示名称，并支持中文和英文标签。

Enhancements:
- 将从 GunsmithLib 派生的统计数据集成到现有的伤害、爆头、RPM、弹丸速度、后坐力和护甲穿透显示中，以准确反映最终数值。
- 扩展护甲无视（护甲穿透率）可视化效果，使用可显示差异的进度条，并在通用渲染中排除集成修正项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable critical attribute display to the gun property diagram UI, including localization support and integration with external attribute and gun libraries.

New Features:
- Display critical chance and critical damage bars in the gun property diagrams using player attribute data.
- Allow configuration of critical attribute IDs and display names with support for Chinese and English labels via config.

Enhancements:
- Integrate GunsmithLib-derived stats into existing damage, headshot, RPM, projectile speed, recoil, and armor penetration displays to reflect final values accurately.
- Extend armor ignore (armor piercing ratio) visualization with diff-aware progress bars and exclude integrated modifiers from generic rendering.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 新增暴击率与暴击伤害属性显示功能。
  * 添加中英文双语言支持，用户可根据偏好选择显示语言。
  * 改进属性面板的绘制逻辑，更准确地展示各类伤害数据与属性信息。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xlxyvergil/TaczAttributeAdd/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->